### PR TITLE
fix legacy file cache

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -165,7 +165,7 @@ const AFTER_HELP: &str = indoc! {"
 "};
 
 #[cfg(test)]
-mod test {
+pub mod test {
     use crate::config::settings::MissingRuntimeBehavior::AutoInstall;
     use crate::config::settings::Settings;
     use crate::output::OutputStream;

--- a/src/plugins.rs
+++ b/src/plugins.rs
@@ -423,7 +423,7 @@ impl Plugin {
             return Ok(None);
         }
 
-        Ok(Some(fs::read_to_string(legacy_file)?.trim().into()))
+        Ok(Some(fs::read_to_string(fp)?.trim().into()))
     }
 
     fn legacy_cache_file_path(&self, legacy_file: &Path) -> PathBuf {
@@ -500,4 +500,26 @@ impl Display for PluginSource {
 fn display_path(path: &Path) -> String {
     let home = dirs::HOME.to_string_lossy();
     path.to_string_lossy().replace(home.as_ref(), "~")
+}
+
+#[cfg(test)]
+mod test {
+    use pretty_assertions::assert_str_eq;
+
+    use crate::assert_cli;
+
+    use super::*;
+
+    #[test]
+    fn test_legacy_gemfile() {
+        assert_cli!("plugin", "add", "ruby");
+        let plugin = Plugin::load(&PluginName::from("ruby")).unwrap();
+        let gemfile = env::HOME.join("fixtures/Gemfile");
+        let version = plugin.parse_legacy_file(&gemfile).unwrap();
+        assert_str_eq!(version, "3.0.5");
+
+        // do it again to test the cache
+        let version = plugin.parse_legacy_file(&gemfile).unwrap();
+        assert_str_eq!(version, "3.0.5");
+    }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,9 +1,12 @@
+use std::fs;
+
 use crate::cmd;
 
 #[ctor::ctor]
 fn init() {
     std::env::set_var("NO_COLOR", "1");
     env_logger::init();
+    let _ = fs::remove_dir_all("test/data/legacy_cache");
     if let Err(err) = cmd!(
         "git",
         "checkout",

--- a/test/fixtures/Gemfile
+++ b/test/fixtures/Gemfile
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+ruby "3.0.5"
+
+source "https://rubygems.org"
+git_source(:github) { |repo| "https://github.com/#{repo}.git" }


### PR DESCRIPTION
Fixes #11

before this would read the legacy file instead of the cache file.

That was fine when I was using .node-version (since they had the same content) but Gemfiles do not.