### PR TITLE
fix `rtx where`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1040,7 +1040,7 @@ Examples:
 ### `rtx uninstall`
 
 ```
-removes a runtime version
+removes runtime versions
 
 Usage: uninstall <RUNTIME>...
 
@@ -1054,7 +1054,8 @@ Options:
 
 
 Examples:
-  $ rtx uninstall nodejs
+  $ rtx uninstall nodejs@18 # will uninstall ALL nodejs-18.x versions
+  $ rtx uninstall nodejs    # will uninstall ALL nodejs versions
 
 ```
 ### `rtx version`

--- a/src/cli/current.rs
+++ b/src/cli/current.rs
@@ -67,9 +67,10 @@ mod test {
 
     #[test]
     fn test_current_with_runtimes() {
+        assert_cli!("plugin", "add", "shfmt");
         assert_cli!("install");
         let Output { stdout, .. } = assert_cli!("current", "shfmt");
-        let re = Regex::new(r"-> shfmt\s+3\.6\.0\s+").unwrap();
+        let re = Regex::new(r"-> shfmt\s+3\.5\.2\s+").unwrap();
         assert!(re.is_match(&stdout.content));
     }
 }

--- a/src/cli/direnv/snapshots/rtx__cli__direnv__envrc__test__direnv_envrc.snap
+++ b/src/cli/direnv/snapshots/rtx__cli__direnv__envrc__test__direnv_envrc.snap
@@ -6,7 +6,7 @@ expression: envrc
 watch_file ~/cwd/.tool-versions
 watch_file ~/cwd/.node-version
 watch_file ~/.tool-versions
-PATH_add ~/data/installs/shfmt/3.6.0/bin
+PATH_add ~/data/installs/shfmt/3.5.2/bin
 PATH_add ~/data/installs/jq/1.6/bin
 PATH_add ~/data/installs/shellcheck/0.9.0/bin
 

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -66,7 +66,7 @@ mod test {
         let Output { stdout, .. } = assert_cli!("env", "-s", "bash");
         assert!(stdout.content.contains(
             dirs::ROOT
-                .join("installs/shfmt/3.6.0/bin")
+                .join("installs/shfmt/3.5.2/bin")
                 .to_string_lossy()
                 .as_ref()
         ));
@@ -80,7 +80,7 @@ mod test {
 
         assert!(stdout.content.contains(
             dirs::ROOT
-                .join("installs/shfmt/3.5.1/bin")
+                .join("installs/shfmt/3.5.2/bin")
                 .to_string_lossy()
                 .as_ref()
         ));

--- a/src/config/config_file/tool_versions.rs
+++ b/src/config/config_file/tool_versions.rs
@@ -179,7 +179,7 @@ pub(crate) mod tests {
         assert_display_snapshot!(tv, @r###"
         #python 3.11.1 3.10.9 # foo
         shellcheck 0.9.0
-        shfmt 3.6.0 # test comment
+        shfmt 3.5.2 # test comment
         #nodejs 18.13.0
         nodejs system
         "###);

--- a/src/config/toolset.rs
+++ b/src/config/toolset.rs
@@ -202,4 +202,21 @@ impl Toolset {
     pub fn get_source_for_plugin(&self, plugin: &PluginName) -> Option<PluginSource> {
         self.current_versions_sources.get(plugin).cloned()
     }
+
+    pub fn find_by_prefix(
+        &self,
+        aliases: &AliasMap,
+        plugin: &str,
+        prefix: &str,
+    ) -> Option<Arc<RuntimeVersion>> {
+        let default_aliases = IndexMap::new();
+        let aliases = aliases.get(plugin).unwrap_or(&default_aliases);
+        let prefix = aliases.get(prefix).cloned().unwrap_or(prefix.to_string());
+
+        let mut versions = self.list_current_versions();
+        versions.extend(self.list_installed_versions());
+        versions
+            .into_iter()
+            .find(|rtv| rtv.plugin.name == plugin && rtv.version.starts_with(&prefix))
+    }
 }

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -54,16 +54,6 @@ impl RuntimeVersion {
         Ok(versions)
     }
 
-    pub fn find_by_version_prefix(plugin: &str, prefix: &str) -> Result<Self> {
-        let rtv = Self::list()?
-            .into_iter()
-            .rev()
-            .find(|rtv| rtv.plugin.name == plugin && rtv.version.starts_with(prefix))
-            .ok_or_else(|| VersionNotInstalled(plugin.into(), prefix.into()))?;
-
-        Ok(rtv)
-    }
-
     pub fn install(&self, install_type: &str, config: &Config) -> Result<()> {
         debug!(
             "install {} {} {}",

--- a/test/cwd/.tool-versions
+++ b/test/cwd/.tool-versions
@@ -1,5 +1,5 @@
 #python 3.11.1 3.10.9 # foo
 shellcheck 0.9.0
-shfmt 3.6.0 # test comment
+shfmt 3.5.2 # test comment
 #nodejs 18.13.0
 nodejs system


### PR DESCRIPTION
Fixes #22

These both had faulty logic when fetching versions. The way it's supposed to be:

- `rtx where nodejs` – fetches either the current nodejs from tool-version, or the latest installed version
- `rtx uninstall nodejs@18` – uninstall ALL nodejs versions matching 18*
- `rtx uninstall nodejs` – uninstall ALL nodejs versions

Frankly I'm not entirely sure if the uninstall behavior is what people expect. They may think `rtx uninstall nodejs` only uninstalls the _current_ node version, but I feel in that case I'm not sure what it should do if there are installed but not current versions.

Uninstalling all seems like at least the simplest strategy for now.