### PR TITLE
feat: colored help

### DIFF
--- a/README.md
+++ b/README.md
@@ -524,7 +524,6 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
-
 Examples:
     $ eval "$(rtx activate bash)"
     $ eval "$(rtx activate zsh)"
@@ -574,7 +573,6 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
-
 Examples:
   $ rtx complete
 
@@ -600,9 +598,7 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
-
 Examples:
-
   # outputs `.tool-versions` compatible format
   $ rtx current
   python 3.11.0 3.10.0
@@ -637,12 +633,11 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
-
 Examples:
-    $ eval "$(rtx deactivate bash)"
-    $ eval "$(rtx deactivate zsh)"
-    $ rtx deactivate fish | source
-    $ execx($(rtx deactivate xonsh))
+  $ eval "$(rtx deactivate bash)"
+  $ eval "$(rtx deactivate zsh)"
+  $ rtx deactivate fish | source
+  $ execx($(rtx deactivate xonsh))
 
 ```
 ### `rtx direnv activate`
@@ -662,11 +657,10 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
-
 Examples:
-    $ rtx direnv activate > ~/.config/direnv/lib/use_rtx.sh
-    $ echo 'use rtx' > .envrc
-    $ direnv allow
+  $ rtx direnv activate > ~/.config/direnv/lib/use_rtx.sh
+  $ echo 'use rtx' > .envrc
+  $ direnv allow
 
 ```
 ### `rtx doctor`
@@ -679,7 +673,6 @@ Usage: doctor
 Options:
   -h, --help
           Print help (see a summary with '-h')
-
 
 Examples:
   $ rtx doctor
@@ -711,7 +704,6 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
-
 
 Examples:
   $ eval "$(rtx env -s bash)"
@@ -752,12 +744,11 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
-
 Examples:
   rtx exec nodejs@20 -- node ./app.js  # launch app.js using node-20.x
   rtx x nodejs@20 -- node ./app.js     # shorter alias
 
-Specify command as a string:
+  # Specify command as a string:
   rtx exec nodejs@20 python@3.11 --command "node -v && python -V"
 
 ```
@@ -787,11 +778,10 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
-
 Examples:
   # set the current version of nodejs to 20.x
   # will use a precise version (e.g.: 20.0.0) in .tool-versions file
-  $ rtx global nodejs@20     
+  $ rtx global nodejs@20
 
   # set the current version of nodejs to 20.x
   # will use a fuzzy version (e.g.: 20) in .tool-versions file
@@ -832,7 +822,6 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
-
 Examples:
   $ rtx install nodejs@18.0.0  # install specific nodejs version
   $ rtx install nodejs@18      # install fuzzy nodejs version
@@ -856,11 +845,10 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
-
 Examples:
   $ rtx latest nodejs@18  # get the latest version of nodejs 18
   18.0.0
-  
+
   $ rtx latest nodejs     # get the latest stable version of nodejs
   20.0.0
 
@@ -896,7 +884,6 @@ Options:
 
   -h, --help
           Print help (see a summary with '-h')
-
 
 Examples:
   # set the current version of nodejs to 20.x for the current directory
@@ -934,13 +921,12 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
-
 Examples:
   $ rtx list
   -> nodejs     20.0.0 (set by ~/src/myapp/.tool-versions)
   -> python     3.11.0 (set by ~/.tool-versions)
      python     3.10.0
-     
+
   $ rtx list --current
   -> nodejs     20.0.0 (set by ~/src/myapp/.tool-versions)
   -> python     3.11.0 (set by ~/.tool-versions)
@@ -963,7 +949,6 @@ Arguments:
 Options:
   -h, --help
           Print help (see a summary with '-h')
-
 
 Examples:
   $ rtx list-remote nodejs
@@ -1010,17 +995,16 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
+Examples:
+  $ rtx install nodejs  # install the nodejs plugin using the shorthand repo:
+                      # https://github.com/asdf-vm/asdf-plugins
 
-EXAMPLES:
-    $ rtx install nodejs  # install the nodejs plugin using the shorthand repo:
-                          # https://github.com/asdf-vm/asdf-plugins
+  $ rtx install nodejs https://github.com/asdf-vm/asdf-nodejs.git
+                      # install the nodejs plugin using the git url
 
-    $ rtx install nodejs https://github.com/asdf-vm/asdf-nodejs.git
-                          # install the nodejs plugin using the git url
-
-    $ rtx install https://github.com/asdf-vm/asdf-nodejs.git
-                          # install the nodejs plugin using the git url only
-                          # (nodejs is inferred from the url)
+  $ rtx install https://github.com/asdf-vm/asdf-nodejs.git
+                      # install the nodejs plugin using the git url only
+                      # (nodejs is inferred from the url)
 
 ```
 ### `rtx plugins ls`
@@ -1046,15 +1030,11 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
-List installed plugins
-Can also show remotely available plugins to install.
-
 Examples:
-
   $ rtx plugins ls
   nodejs
   ruby
-  
+
   $ rtx plugins ls --urls
   nodejs                        https://github.com/asdf-vm/asdf-nodejs.git
   ruby                          https://github.com/asdf-vm/asdf-ruby.git
@@ -1098,7 +1078,6 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
-
 Examples:
   $ rtx uninstall nodejs
 
@@ -1123,10 +1102,9 @@ Options:
   -h, --help
           Print help (see a summary with '-h')
 
-
 Examples:
-  rtx plugins update --all   # update all plugins
-  rtx plugins update nodejs  # update only nodejs
+  $ rtx plugins update --all   # update all plugins
+  $ rtx plugins update nodejs  # update only nodejs
 
 ```
 ### `rtx settings get`
@@ -1234,7 +1212,6 @@ Arguments:
 Options:
   -h, --help
           Print help (see a summary with '-h')
-
 
 Examples:
   $ rtx uninstall nodejs@18 # will uninstall ALL nodejs-18.x versions

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -1,10 +1,14 @@
+use atty::Stream;
 use color_eyre::eyre::Result;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 use crate::cli::command::Command;
 use crate::config::Config;
 use crate::env;
 use crate::output::Output;
 use crate::shell::{get_shell, ShellType};
+use crate::ui::color::Color;
 
 /// Enables rtx to automatically modify runtimes when changing directory
 ///
@@ -12,7 +16,7 @@ use crate::shell::{get_shell, ShellType};
 /// Otherwise, it will only take effect in the current session.
 /// (e.g. ~/.bashrc)
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct Activate {
     /// Shell type to generate the script for
     #[clap(long, short, hide = true)]
@@ -50,13 +54,16 @@ impl Command for Activate {
     }
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
-    $ eval "$(rtx activate bash)"
-    $ eval "$(rtx activate zsh)"
-    $ rtx activate fish | source
-    $ execx($(rtx activate xonsh))
-"#;
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+        $ eval "$(rtx activate bash)"
+        $ eval "$(rtx activate zsh)"
+        $ rtx activate fish | source
+        $ execx($(rtx activate xonsh))
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/alias/ls.rs
+++ b/src/cli/alias/ls.rs
@@ -1,10 +1,13 @@
+use atty::Stream;
 use color_eyre::eyre::Result;
-use indoc::indoc;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 use crate::cli::command::Command;
 use crate::config::Config;
 use crate::output::Output;
 use crate::plugins::PluginName;
+use crate::ui::color::Color;
 
 /// List aliases
 /// Shows the aliases that can be specified.
@@ -15,7 +18,7 @@ use crate::plugins::PluginName;
 ///   [alias.nodejs]
 ///   lts = "18.0.0"
 #[derive(Debug, clap::Args)]
-#[clap(visible_alias = "list", after_long_help = AFTER_LONG_HELP, verbatim_doc_comment)]
+#[clap(visible_alias = "list", after_long_help = AFTER_LONG_HELP.as_str(), verbatim_doc_comment)]
 pub struct AliasLs {
     /// Show aliases for <PLUGIN>
     #[clap(short, long)]
@@ -39,11 +42,14 @@ impl Command for AliasLs {
     }
 }
 
-const AFTER_LONG_HELP: &str = indoc! {r#"
-    Examples:
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
       $ rtx aliases
       nodejs    lts/hydrogen   18.0.0
-    "#};
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/complete.rs
+++ b/src/cli/complete.rs
@@ -1,3 +1,4 @@
+use atty::Stream;
 use color_eyre::eyre::Result;
 use std::io::Cursor;
 
@@ -6,11 +7,14 @@ use crate::config::Config;
 use crate::output::Output;
 
 use crate::cli::Cli;
+use crate::ui::color::Color;
 use clap_complete::generate;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 /// generate shell completions
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct Complete {
     /// shell type
     #[clap(long, short)]
@@ -27,10 +31,13 @@ impl Command for Complete {
     }
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
-  $ rtx complete
-"#;
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      $ rtx complete
+    "#, COLOR.header("Examples:")}
+});
 
 // #[cfg(test)]
 // mod test {

--- a/src/cli/current.rs
+++ b/src/cli/current.rs
@@ -1,10 +1,14 @@
+use atty::Stream;
 use color_eyre::eyre::Result;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 use std::sync::Arc;
 
 use crate::cli::command::Command;
 use crate::config::Config;
 use crate::output::Output;
 use crate::plugins::Plugin;
+use crate::ui::color::Color;
 
 /// Shows currently active, and installed runtime versions
 ///
@@ -12,7 +16,7 @@ use crate::plugins::Plugin;
 /// only shows the runtime and/or version so it's
 /// designed to fit into scripts more easily.
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct Current {
     /// plugin to show versions of
     ///
@@ -88,23 +92,25 @@ impl Current {
     }
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      # outputs `.tool-versions` compatible format
+      $ rtx current
+      python 3.11.0 3.10.0
+      shfmt 3.6.0
+      shellcheck 0.9.0
+      nodejs 18.13.0
 
-  # outputs `.tool-versions` compatible format
-  $ rtx current
-  python 3.11.0 3.10.0
-  shfmt 3.6.0
-  shellcheck 0.9.0
-  nodejs 18.13.0
+      $ rtx current nodejs
+      18.13.0
 
-  $ rtx current nodejs
-  18.13.0
-
-  # can output multiple versions
-  $ rtx current python
-  3.11.0 3.10.0
-"#;
+      # can output multiple versions
+      $ rtx current python
+      3.11.0 3.10.0
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/deactivate.rs
+++ b/src/cli/deactivate.rs
@@ -1,15 +1,19 @@
+use atty::Stream;
 use color_eyre::eyre::Result;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 use crate::cli::command::Command;
 use crate::config::Config;
 use crate::output::Output;
 use crate::shell::{get_shell, ShellType};
+use crate::ui::color::Color;
 
 /// disable rtx for current shell session
 ///
 /// This can be used to temporarily disable rtx in a shell session.
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct Deactivate {
     /// shell type to generate the script for
     #[clap(long, short, hide = true)]
@@ -31,13 +35,16 @@ impl Command for Deactivate {
     }
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
-    $ eval "$(rtx deactivate bash)"
-    $ eval "$(rtx deactivate zsh)"
-    $ rtx deactivate fish | source
-    $ execx($(rtx deactivate xonsh))
-"#;
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      $ eval "$(rtx deactivate bash)"
+      $ eval "$(rtx deactivate zsh)"
+      $ rtx deactivate fish | source
+      $ execx($(rtx deactivate xonsh))
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/direnv/activate.rs
+++ b/src/cli/direnv/activate.rs
@@ -1,9 +1,12 @@
+use atty::Stream;
 use color_eyre::eyre::Result;
-use indoc::indoc;
+use indoc::{formatdoc, indoc};
+use once_cell::sync::Lazy;
 
 use crate::cli::command::Command;
 use crate::config::Config;
 use crate::output::Output;
+use crate::ui::color::Color;
 
 /// Output direnv function to use rtx inside direnv
 ///
@@ -13,7 +16,7 @@ use crate::output::Output;
 /// you should run this command after installing new plugins. Otherwise
 /// direnv may not know to update environment variables when legacy file versions change.
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct DirenvActivate {}
 
 impl Command for DirenvActivate {
@@ -33,9 +36,12 @@ impl Command for DirenvActivate {
     }
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
-    $ rtx direnv activate > ~/.config/direnv/lib/use_rtx.sh
-    $ echo 'use rtx' > .envrc
-    $ direnv allow
-"#;
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      $ rtx direnv activate > ~/.config/direnv/lib/use_rtx.sh
+      $ echo 'use rtx' > .envrc
+      $ direnv allow
+    "#, COLOR.header("Examples:")}
+});

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -1,13 +1,17 @@
+use atty::Stream;
 use color_eyre::eyre::{eyre, Result};
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 use crate::cli::command::Command;
 use crate::config::Config;
 use crate::env;
 use crate::output::Output;
+use crate::ui::color::Color;
 
 /// Check rtx installation for possible problems.
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct Doctor {}
 
 impl Command for Doctor {
@@ -38,11 +42,14 @@ impl Command for Doctor {
     }
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
-  $ rtx doctor
-  [WARN] plugin nodejs is not installed
-"#;
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      $ rtx doctor
+      [WARN] plugin nodejs is not installed
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -1,10 +1,14 @@
+use atty::Stream;
 use color_eyre::eyre::Result;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 use crate::cli::args::runtime::{RuntimeArg, RuntimeArgParser};
 use crate::cli::command::Command;
 use crate::config::Config;
 use crate::output::Output;
 use crate::shell::{get_shell, ShellType};
+use crate::ui::color::Color;
 
 /// exports env vars to activate rtx in a single shell session
 ///
@@ -14,7 +18,7 @@ use crate::shell::{get_shell, ShellType};
 /// Unfortunately, it requires `eval` to work since it's not written in Bash though.
 /// It's also useful just to see what environment variables rtx sets.
 #[derive(Debug, clap::Args)]
-#[clap(visible_alias = "e", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+#[clap(visible_alias = "e", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct Env {
     /// Shell type to generate environment variables for
     #[clap(long, short)]
@@ -46,13 +50,16 @@ impl Command for Env {
     }
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
-  $ eval "$(rtx env -s bash)"
-  $ eval "$(rtx env -s zsh)"
-  $ rtx env -s fish | source
-  $ execx($(rtx env -s xonsh))
-"#;
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      $ eval "$(rtx env -s bash)"
+      $ eval "$(rtx env -s zsh)"
+      $ rtx env -s fish | source
+      $ execx($(rtx env -s xonsh))
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -1,10 +1,14 @@
+use atty::Stream;
 use color_eyre::eyre::Result;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 use crate::cli::args::runtime::{RuntimeArg, RuntimeArgParser};
 use crate::cli::command::Command;
 use crate::config::{config_file, Config};
 use crate::output::Output;
 use crate::plugins::PluginName;
+use crate::ui::color::Color;
 use crate::{dirs, env};
 
 /// sets global .tool-versions to include a specified runtime
@@ -12,7 +16,7 @@ use crate::{dirs, env};
 /// this file is `$HOME/.tool-versions` by default
 /// use `rtx local` to set a runtime version locally in the current directory
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, visible_alias = "g", after_long_help = AFTER_LONG_HELP)]
+#[clap(verbatim_doc_comment, visible_alias = "g", after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct Global {
     /// runtimes
     ///
@@ -60,16 +64,19 @@ impl Command for Global {
     }
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
-  # set the current version of nodejs to 20.x
-  # will use a precise version (e.g.: 20.0.0) in .tool-versions file
-  $ rtx global nodejs@20     
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      # set the current version of nodejs to 20.x
+      # will use a precise version (e.g.: 20.0.0) in .tool-versions file
+      $ rtx global nodejs@20
 
-  # set the current version of nodejs to 20.x
-  # will use a fuzzy version (e.g.: 20) in .tool-versions file
-  $ rtx global --fuzzy nodejs@20
-"#;
+      # set the current version of nodejs to 20.x
+      # will use a fuzzy version (e.g.: 20) in .tool-versions file
+      $ rtx global --fuzzy nodejs@20
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -1,5 +1,7 @@
 use atty::Stream::Stderr;
 use color_eyre::eyre::Result;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 use owo_colors::Stream;
 
 use crate::cli::args::runtime::{RuntimeArg, RuntimeArgParser};
@@ -11,7 +13,7 @@ use crate::output::Output;
 use crate::plugins::InstallType::Version;
 use crate::plugins::{Plugin, PluginName};
 use crate::runtimes::RuntimeVersion;
-use crate::ui::color::cyan;
+use crate::ui::color::{cyan, Color};
 
 /// install a runtime
 ///
@@ -20,7 +22,7 @@ use crate::ui::color::cyan;
 /// For that, you must set up a `.tool-version` file manually or with `rtx local/global`.
 /// Or you can call a runtime explicitly with `rtx exec <PLUGIN>@<VERSION> -- <COMMAND>`.
 #[derive(Debug, clap::Args)]
-#[clap(visible_alias = "i", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+#[clap(visible_alias = "i", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct Install {
     /// runtime(s) to install
     ///
@@ -147,14 +149,17 @@ fn get_all_plugin_names(config: &Config) -> Vec<String> {
         .collect()
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
-  $ rtx install nodejs@18.0.0  # install specific nodejs version
-  $ rtx install nodejs@18      # install fuzzy nodejs version
-  $ rtx install nodejs         # install version specified in .tool-versions
-  $ rtx install                # installs all runtimes specified in .tool-versions for installed plugins
-  $ rtx install --all          # installs all runtimes and all plugins
-"#;
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      $ rtx install nodejs@18.0.0  # install specific nodejs version
+      $ rtx install nodejs@18      # install fuzzy nodejs version
+      $ rtx install nodejs         # install version specified in .tool-versions
+      $ rtx install                # installs all runtimes specified in .tool-versions for installed plugins
+      $ rtx install --all          # installs all runtimes and all plugins
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -1,14 +1,18 @@
+use atty::Stream;
 use color_eyre::eyre::{eyre, Result};
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 use crate::cli::args::runtime::{RuntimeArg, RuntimeArgParser, RuntimeArgVersion};
 use crate::cli::command::Command;
 use crate::config::Config;
 use crate::output::Output;
 use crate::plugins::Plugin;
+use crate::ui::color::Color;
 
 /// get the latest runtime version of a plugin's runtimes
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct Latest {
     /// Runtime to get the latest version of
     #[clap(value_parser = RuntimeArgParser)]
@@ -41,14 +45,17 @@ impl Command for Latest {
     }
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
-  $ rtx latest nodejs@18  # get the latest version of nodejs 18
-  18.0.0
-  
-  $ rtx latest nodejs     # get the latest stable version of nodejs
-  20.0.0
-"#;
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      $ rtx latest nodejs@18  # get the latest version of nodejs 18
+      18.0.0
+
+      $ rtx latest nodejs     # get the latest stable version of nodejs
+      20.0.0
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -1,10 +1,14 @@
+use atty::Stream;
 use color_eyre::eyre::{eyre, ContextCompat, Result};
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 use crate::cli::args::runtime::{RuntimeArg, RuntimeArgParser};
 use crate::cli::command::Command;
 use crate::config::{config_file, Config};
 use crate::output::Output;
 use crate::plugins::PluginName;
+use crate::ui::color::Color;
 use crate::{dirs, env, file};
 
 /// Sets .tool-versions to include a specific runtime
@@ -12,7 +16,7 @@ use crate::{dirs, env, file};
 /// use this to set the runtime version when within a directory
 /// use `rtx global` to set a runtime version globally
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, visible_alias = "l", after_long_help = AFTER_LONG_HELP)]
+#[clap(verbatim_doc_comment, visible_alias = "l", after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct Local {
     /// runtimes to add to .tool-versions
     ///
@@ -78,22 +82,25 @@ impl Command for Local {
     }
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
-  # set the current version of nodejs to 20.x for the current directory
-  # will use a precise version (e.g.: 20.0.0) in .tool-versions file
-  $ rtx local nodejs@20
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      # set the current version of nodejs to 20.x for the current directory
+      # will use a precise version (e.g.: 20.0.0) in .tool-versions file
+      $ rtx local nodejs@20
 
-  # set nodejs to 20.x for the current project (recurses up to find .tool-versions)
-  $ rtx local -p nodejs@20
+      # set nodejs to 20.x for the current project (recurses up to find .tool-versions)
+      $ rtx local -p nodejs@20
 
-  # set the current version of nodejs to 20.x for the current directory
-  # will use a fuzzy version (e.g.: 20) in .tool-versions file
-  $ rtx local --fuzzy nodejs@20
+      # set the current version of nodejs to 20.x for the current directory
+      # will use a fuzzy version (e.g.: 20) in .tool-versions file
+      $ rtx local --fuzzy nodejs@20
 
-  # removes nodejs from .tool-versions
-  $ rtx local --remove=nodejs
-"#;
+      # removes nodejs from .tool-versions
+      $ rtx local --remove=nodejs
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -4,7 +4,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use color_eyre::eyre::Result;
+use indoc::formatdoc;
 use itertools::Itertools;
+use once_cell::sync::Lazy;
 use owo_colors::{OwoColorize, Stream};
 use versions::Versioning;
 
@@ -13,14 +15,14 @@ use crate::config::{Config, PluginSource};
 use crate::output::Output;
 use crate::plugins::PluginName;
 use crate::runtimes::RuntimeVersion;
-use crate::ui::color::{cyan, dimmed, green, red};
+use crate::ui::color::{cyan, dimmed, green, red, Color};
 
 /// list installed runtime versions
 ///
 /// The "arrow (->)" indicates the runtime is installed, active, and will be used for running commands.
 /// (Assuming `rtx activate` or `rtx env` is in use).
 #[derive(Debug, clap::Args)]
-#[clap(visible_alias = "list", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+#[clap(visible_alias = "list", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct Ls {
     /// Only show runtimes from [PLUGIN]
     #[clap(long, short)]
@@ -132,17 +134,20 @@ fn get_runtime_list(
     Ok(rvs)
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
-  $ rtx list
-  -> nodejs     20.0.0 (set by ~/src/myapp/.tool-versions)
-  -> python     3.11.0 (set by ~/.tool-versions)
-     python     3.10.0
-     
-  $ rtx list --current
-  -> nodejs     20.0.0 (set by ~/src/myapp/.tool-versions)
-  -> python     3.11.0 (set by ~/.tool-versions)
-"#;
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      $ rtx list
+      -> nodejs     20.0.0 (set by ~/src/myapp/.tool-versions)
+      -> python     3.11.0 (set by ~/.tool-versions)
+         python     3.10.0
+
+      $ rtx list --current
+      -> nodejs     20.0.0 (set by ~/src/myapp/.tool-versions)
+      -> python     3.11.0 (set by ~/.tool-versions)
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/ls_remote.rs
+++ b/src/cli/ls_remote.rs
@@ -1,16 +1,20 @@
+use atty::Stream;
 use color_eyre::eyre::Result;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 use crate::cli::command::Command;
 use crate::config::Config;
 use crate::errors::Error::PluginNotInstalled;
 use crate::output::Output;
+use crate::ui::color::Color;
 
 /// list runtime versions available for install
 ///
 /// note that these versions are cached for commands like `rtx install nodejs@latest`
 /// however _this_ command will always clear that cache and fetch the latest remote versions
 #[derive(Debug, clap::Args)]
-#[clap(visible_alias = "list-remote", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+#[clap(visible_alias = "list-remote", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct LsRemote {
     /// Plugin
     #[clap()]
@@ -33,12 +37,15 @@ impl Command for LsRemote {
     }
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
-  $ rtx list-remote nodejs
-  18.0.0
-  20.0.0
-"#;
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      $ rtx list-remote nodejs
+      18.0.0
+      20.0.0
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/plugins/install.rs
+++ b/src/cli/plugins/install.rs
@@ -1,6 +1,9 @@
+use atty::Stream;
 use std::sync::Arc;
 
 use color_eyre::eyre::{eyre, Result};
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 use url::Url;
 
 use crate::cli::command::Command;
@@ -8,6 +11,7 @@ use crate::config::Config;
 use crate::output::Output;
 use crate::plugins::Plugin;
 use crate::shorthand_repository::ShorthandRepo;
+use crate::ui::color::Color;
 
 /// install a plugin
 ///
@@ -16,7 +20,7 @@ use crate::shorthand_repository::ShorthandRepo;
 ///
 /// This behavior can be modified in ~/.rtx/config.toml
 #[derive(Debug, clap::Args)]
-#[clap(visible_aliases = ["i", "a"], alias = "add", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
+#[clap(visible_aliases = ["i", "a"], alias = "add", verbatim_doc_comment, after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct PluginsInstall {
     /// The name of the plugin to install
     ///
@@ -118,18 +122,21 @@ fn get_name_from_url(url: &str) -> Result<String> {
     Err(eyre!("could not infer plugin name from url: {}", url))
 }
 
-const AFTER_LONG_HELP: &str = r#"
-EXAMPLES:
-    $ rtx install nodejs  # install the nodejs plugin using the shorthand repo:
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      $ rtx install nodejs  # install the nodejs plugin using the shorthand repo:
                           # https://github.com/asdf-vm/asdf-plugins
 
-    $ rtx install nodejs https://github.com/asdf-vm/asdf-nodejs.git
+      $ rtx install nodejs https://github.com/asdf-vm/asdf-nodejs.git
                           # install the nodejs plugin using the git url
 
-    $ rtx install https://github.com/asdf-vm/asdf-nodejs.git
+      $ rtx install https://github.com/asdf-vm/asdf-nodejs.git
                           # install the nodejs plugin using the git url only
                           # (nodejs is inferred from the url)
-"#;
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/plugins/ls.rs
+++ b/src/cli/plugins/ls.rs
@@ -1,16 +1,19 @@
+use atty::Stream;
 use color_eyre::eyre::Result;
-use indoc::indoc;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 use crate::cli::command::Command;
 use crate::cli::plugins::ls_remote::PluginsLsRemote;
 use crate::config::Config;
 use crate::output::Output;
+use crate::ui::color::Color;
 
 /// List installed plugins
 ///
 /// Can also show remotely available plugins to install.
 #[derive(Debug, clap::Args)]
-#[clap(visible_alias = "list", after_long_help = AFTER_LONG_HELP, verbatim_doc_comment)]
+#[clap(visible_alias = "list", after_long_help = AFTER_LONG_HELP.as_str(), verbatim_doc_comment)]
 pub struct PluginsLs {
     /// list all available remote plugins
     ///
@@ -44,20 +47,19 @@ impl Command for PluginsLs {
     }
 }
 
-const AFTER_LONG_HELP: &str = indoc! {r#"
-    List installed plugins
-    Can also show remotely available plugins to install.
-
-    Examples:
-    
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
       $ rtx plugins ls
       nodejs
       ruby
-      
+
       $ rtx plugins ls --urls
       nodejs                        https://github.com/asdf-vm/asdf-nodejs.git
       ruby                          https://github.com/asdf-vm/asdf-ruby.git
-    "#};
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/plugins/uninstall.rs
+++ b/src/cli/plugins/uninstall.rs
@@ -1,13 +1,16 @@
 use color_eyre::eyre::Result;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 use owo_colors::{OwoColorize, Stream};
 
 use crate::cli::command::Command;
 use crate::config::Config;
 use crate::output::Output;
+use crate::ui::color::Color;
 
 /// removes a plugin
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, alias = "remove", alias = "rm", after_long_help = AFTER_LONG_HELP)]
+#[clap(verbatim_doc_comment, alias = "remove", alias = "rm", after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct PluginsUninstall {
     /// plugin to remove
     #[clap()]
@@ -37,10 +40,13 @@ impl Command for PluginsUninstall {
     }
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
-  $ rtx uninstall nodejs
-"#;
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      $ rtx uninstall nodejs
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/plugins/update.rs
+++ b/src/cli/plugins/update.rs
@@ -1,19 +1,21 @@
 use std::sync::Arc;
 
 use color_eyre::eyre::{eyre, Result};
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 use owo_colors::Stream;
 
 use crate::cli::command::Command;
 use crate::config::Config;
 use crate::output::Output;
 use crate::plugins::Plugin;
-use crate::ui::color::cyan;
+use crate::ui::color::{cyan, Color};
 
 /// updates a plugin to the latest version
 ///
 /// note: this updates the plugin itself, not the runtime versions
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, alias = "upgrade", after_long_help = AFTER_LONG_HELP)]
+#[clap(verbatim_doc_comment, alias = "upgrade", after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct Update {
     /// plugin(s) to update
     #[clap()]
@@ -47,11 +49,14 @@ impl Command for Update {
     }
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
-  rtx plugins update --all   # update all plugins
-  rtx plugins update nodejs  # update only nodejs
-"#;
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      $ rtx plugins update --all   # update all plugins
+      $ rtx plugins update nodejs  # update only nodejs
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/settings/get.rs
+++ b/src/cli/settings/get.rs
@@ -1,9 +1,12 @@
+use atty::Stream;
 use color_eyre::eyre::{eyre, Result};
-use indoc::indoc;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 use crate::cli::command::Command;
 use crate::config::Config;
 use crate::output::Output;
+use crate::ui::color::Color;
 
 /// Show a current setting
 ///
@@ -12,7 +15,7 @@ use crate::output::Output;
 /// Note that aliases are also stored in this file
 /// but managed separately with `rtx aliases get`
 #[derive(Debug, clap::Args)]
-#[clap(after_long_help = AFTER_LONG_HELP, verbatim_doc_comment)]
+#[clap(after_long_help = AFTER_LONG_HELP.as_str(), verbatim_doc_comment)]
 pub struct SettingsGet {
     /// The setting to show
     pub key: String,
@@ -27,11 +30,14 @@ impl Command for SettingsGet {
     }
 }
 
-const AFTER_LONG_HELP: &str = indoc! {r#"
-    Examples:
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
       $ rtx settings get legacy_version_file
       true
-    "#};
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/settings/ls.rs
+++ b/src/cli/settings/ls.rs
@@ -1,9 +1,12 @@
+use atty::Stream;
 use color_eyre::eyre::Result;
-use indoc::indoc;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 use crate::cli::command::Command;
 use crate::config::Config;
 use crate::output::Output;
+use crate::ui::color::Color;
 
 /// Show current settings
 ///
@@ -12,7 +15,7 @@ use crate::output::Output;
 /// Note that aliases are also stored in this file
 /// but managed separately with `rtx aliases`
 #[derive(Debug, clap::Args)]
-#[clap(visible_alias = "list", after_long_help = AFTER_LONG_HELP, verbatim_doc_comment)]
+#[clap(visible_alias = "list", after_long_help = AFTER_LONG_HELP.as_str(), verbatim_doc_comment)]
 pub struct SettingsLs {}
 
 impl Command for SettingsLs {
@@ -24,11 +27,14 @@ impl Command for SettingsLs {
     }
 }
 
-const AFTER_LONG_HELP: &str = indoc! {r#"
-    Examples:
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
       $ rtx settings
       legacy_version_file = false
-    "#};
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/settings/set.rs
+++ b/src/cli/settings/set.rs
@@ -1,16 +1,19 @@
+use atty::Stream;
 use color_eyre::eyre::{eyre, Result};
-use indoc::indoc;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 use crate::cli::command::Command;
 use crate::config::config_file::ConfigFile;
 use crate::config::Config;
 use crate::output::Output;
+use crate::ui::color::Color;
 
 /// Add/update a setting
 ///
 /// This modifies the contents of ~/.config/rtx/config.toml
 #[derive(Debug, clap::Args)]
-#[clap(visible_aliases = ["add", "create"], after_long_help = AFTER_LONG_HELP, verbatim_doc_comment)]
+#[clap(visible_aliases = ["add", "create"], after_long_help = AFTER_LONG_HELP.as_str(), verbatim_doc_comment)]
 pub struct SettingsSet {
     /// The setting to set
     pub key: String,
@@ -52,10 +55,13 @@ fn parse_i64(value: &str) -> Result<toml_edit::Value> {
     }
 }
 
-const AFTER_LONG_HELP: &str = indoc! {r#"
-    Examples:
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
       $ rtx settings set legacy_version_file true
-    "#};
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 pub mod test {

--- a/src/cli/settings/unset.rs
+++ b/src/cli/settings/unset.rs
@@ -1,16 +1,19 @@
+use atty::Stream;
 use color_eyre::eyre::Result;
-use indoc::indoc;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 use crate::cli::command::Command;
 use crate::config::config_file::ConfigFile;
 use crate::config::Config;
 use crate::output::Output;
+use crate::ui::color::Color;
 
 /// Clears a setting
 ///
 /// This modifies the contents of ~/.config/rtx/config.toml
 #[derive(Debug, clap::Args)]
-#[clap(visible_aliases=["rm", "remove", "delete", "del"], after_long_help = AFTER_LONG_HELP, verbatim_doc_comment)]
+#[clap(visible_aliases=["rm", "remove", "delete", "del"], after_long_help = AFTER_LONG_HELP.as_str(), verbatim_doc_comment)]
 pub struct SettingsUnset {
     /// The setting to remove
     pub key: String,
@@ -24,10 +27,13 @@ impl Command for SettingsUnset {
     }
 }
 
-const AFTER_LONG_HELP: &str = indoc! {r#"
-    Examples:
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
       $ rtx settings unset legacy_version_file
-    "#};
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/cli/uninstall.rs
+++ b/src/cli/uninstall.rs
@@ -1,5 +1,7 @@
 use color_eyre::eyre::{eyre, Result, WrapErr};
+use indoc::formatdoc;
 use itertools::Itertools;
+use once_cell::sync::Lazy;
 use owo_colors::OwoColorize;
 use owo_colors::Stream;
 
@@ -8,10 +10,11 @@ use crate::cli::command::Command;
 use crate::config::Config;
 use crate::errors::Error::VersionNotInstalled;
 use crate::output::Output;
+use crate::ui::color::Color;
 
 /// removes runtime versions
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, alias = "remove", alias = "rm", after_long_help = AFTER_LONG_HELP)]
+#[clap(verbatim_doc_comment, alias = "remove", alias = "rm", after_long_help = AFTER_LONG_HELP.as_str())]
 pub struct Uninstall {
     /// runtime(s) to remove
     #[clap(required = true, value_parser = RuntimeArgParser)]
@@ -73,8 +76,11 @@ impl Command for Uninstall {
     }
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
-  $ rtx uninstall nodejs@18 # will uninstall ALL nodejs-18.x versions
-  $ rtx uninstall nodejs    # will uninstall ALL nodejs versions
-"#;
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      $ rtx uninstall nodejs@18 # will uninstall ALL nodejs-18.x versions
+      $ rtx uninstall nodejs    # will uninstall ALL nodejs versions
+    "#, COLOR.header("Examples:")}
+});

--- a/src/cli/where.rs
+++ b/src/cli/where.rs
@@ -1,16 +1,20 @@
+use atty::Stream;
 use color_eyre::eyre::Result;
+use indoc::formatdoc;
+use once_cell::sync::Lazy;
 
 use crate::cli::args::runtime::{RuntimeArg, RuntimeArgParser};
 use crate::cli::command::Command;
 use crate::config::Config;
 use crate::errors::Error::VersionNotInstalled;
 use crate::output::Output;
+use crate::ui::color::Color;
 
 /// Display the installation path for a runtime
 ///
 /// Must be installed.
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP, hide = true)]
+#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP.as_str(), hide = true)]
 pub struct Where {
     /// runtime(s) to look up
     /// if "@<PREFIX>" is specified, it will show the latest installed version that matches the prefix
@@ -45,19 +49,21 @@ impl Command for Where {
     }
 }
 
-const AFTER_LONG_HELP: &str = r#"
-Examples:
+static COLOR: Lazy<Color> = Lazy::new(|| Color::new(Stream::Stdout));
+static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
+    formatdoc! {r#"
+    {}
+      # Show the latest installed version of nodejs
+      # If it is is not installed, errors
+      $ rtx where nodejs@20
+      /Users/jdx/.local/share/rtx/installs/nodejs/20.0.0
 
-  # Show the latest installed version of nodejs
-  # If it is is not installed, errors
-  $ rtx where nodejs@20
-  /Users/jdx/.local/share/rtx/installs/nodejs/20.0.0
-
-  # Show the current, active install directory of nodejs
-  # Errors if nodejs is not referenced in any .tool-version file
-  $ rtx where nodejs
-  /Users/jdx/.local/share/rtx/installs/nodejs/20.0.0
-"#;
+      # Show the current, active install directory of nodejs
+      # Errors if nodejs is not referenced in any .tool-version file
+      $ rtx where nodejs
+      /Users/jdx/.local/share/rtx/installs/nodejs/20.0.0
+    "#, COLOR.header("Examples:")}
+});
 
 #[cfg(test)]
 mod test {

--- a/src/ui/color.rs
+++ b/src/ui/color.rs
@@ -21,3 +21,26 @@ pub fn _bright_green(stream: Stream, s: &str) -> String {
 pub fn red(stream: Stream, s: &str) -> String {
     s.if_supports_color(stream, |s| s.red()).to_string()
 }
+
+pub struct Color {
+    stream: Stream,
+}
+
+impl Color {
+    pub fn new(stream: Stream) -> Self {
+        Self { stream }
+    }
+
+    pub fn header(&self, title: &str) -> String {
+        self.underline(&self.bold(title))
+    }
+
+    pub fn bold(&self, s: &str) -> String {
+        s.if_supports_color(self.stream, |s| s.bold()).to_string()
+    }
+
+    pub fn underline(&self, s: &str) -> String {
+        s.if_supports_color(self.stream, |s| s.underline())
+            .to_string()
+    }
+}


### PR DESCRIPTION
I disabled colored help in Clap because the "Example" headers (which are manually created) would not display in color. This brings it back by manually applying the color to the headers.