### PR TITLE
[feat] show current version on hook-env

### DIFF
--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -17,11 +17,19 @@ pub struct Activate {
     /// Shell type to generate the script for
     #[clap(long, short)]
     shell: Option<ShellType>,
+
+    /// Hide the "rtx: <PLUGIN>@<VERSION>" message when changing directories
+    #[clap(long, short)]
+    quiet: bool,
 }
 
 impl Command for Activate {
     fn run(self, _config: Config, out: &mut Output) -> Result<()> {
         let shell = get_shell(self.shell);
+
+        if self.quiet {
+            rtxprintln!(out, "{}", shell.set_env("RTX_QUIET", "1"));
+        }
 
         let exe = if cfg!(test) {
             "rtx".into()

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -1,4 +1,5 @@
 use color_eyre::eyre::Result;
+use itertools::Itertools;
 
 use crate::cli::command::Command;
 use crate::config::Config;
@@ -42,6 +43,13 @@ impl Command for HookEnv {
         ));
         let output = self.build_env_commands(&patches);
         out.stdout.write(output);
+
+        let installed_versions = config.ts.list_current_installed_versions()
+            .into_iter()
+            .map(|v| v.to_string()).collect_vec();
+        if !installed_versions.is_empty() && !*env::RTX_QUIET {
+            out.stderr.writeln(format!("rtx: {}", installed_versions.join(" ")));
+        }
 
         Ok(())
     }

--- a/src/env.rs
+++ b/src/env.rs
@@ -78,6 +78,7 @@ lazy_static! {
     };
     pub static ref __RTX_DIR: Option<PathBuf> = var_os("__RTX_DIR").map(PathBuf::from);
     pub static ref __RTX_DIFF: EnvDiff = get_env_diff();
+    pub static ref RTX_QUIET: bool = var_is_true("RTX_QUIET");
     pub static ref PRISTINE_ENV: HashMap<String, String> =
         get_pristine_env(&__RTX_DIFF, vars().collect());
     pub static ref RTX_DEFAULT_TOOL_VERSIONS_FILENAME: String = if cfg!(test) {


### PR DESCRIPTION
Looks like this:

```
~/src/chim main ❯ cd src/
rtx: nodejs@16.19.0
```

This is useful to see what rtx is doing. One issue that I need to fix is this displays on every "cd", but it should only show on the ones where the nearest `.tool-versions` file changed.