### PR TITLE
chore: consolidate compression to use zlib for everything

### DIFF
--- a/README.md
+++ b/README.md
@@ -1428,14 +1428,14 @@ to be updating, this is a good place to start.
 
 ### Plugin Cache
 
-Each plugin has a cache that's stored in `~/.local/share/rtx/plugins/<PLUGIN>/.rtxcache.msgpack.gz`. It stores
+Each plugin has a cache that's stored in `~/.local/share/rtx/plugins/<PLUGIN>/.rtxcache.msgpack`. It stores
 the list of versions available for that plugin (`rtx ls-remote <PLUGIN>`) and the legacy filenames (see below).
 
 It is updated daily by default or anytime that `rtx ls-remote` is called explicitly. The file is
 gzipped messagepack, if you want to view it you can run the following (requires [msgpack-cli](https://github.com/msgpack/msgpack-cli)).
 
 ```sh-session
-cat ~/.local/share/rtx/plugins/nodejs/.rtxcache.msgpack.gz | gunzip | msgpack-cli decode
+cat ~/.local/share/rtx/plugins/nodejs/.rtxcache.msgpack.gz | perl -e 'use Compress::Raw::Zlib;my $d=new Compress::Raw::Zlib::Inflate();my $o;undef $/;$d->inflate(<>,$o);print $o;' | msgpack-cli decode
 ```
 
 ### Runtime Cache

--- a/src/cli/render_help.rs
+++ b/src/cli/render_help.rs
@@ -726,14 +726,14 @@ to be updating, this is a good place to start.
 
 ### Plugin Cache
 
-Each plugin has a cache that's stored in `~/.local/share/rtx/plugins/<PLUGIN>/.rtxcache.msgpack.gz`. It stores
+Each plugin has a cache that's stored in `~/.local/share/rtx/plugins/<PLUGIN>/.rtxcache.msgpack`. It stores
 the list of versions available for that plugin (`rtx ls-remote <PLUGIN>`) and the legacy filenames (see below).
 
 It is updated daily by default or anytime that `rtx ls-remote` is called explicitly. The file is
 gzipped messagepack, if you want to view it you can run the following (requires [msgpack-cli](https://github.com/msgpack/msgpack-cli)).
 
 ```sh-session
-cat ~/.local/share/rtx/plugins/nodejs/.rtxcache.msgpack.gz | gunzip | msgpack-cli decode
+cat ~/.local/share/rtx/plugins/nodejs/.rtxcache.msgpack.gz | perl -e 'use Compress::Raw::Zlib;my $d=new Compress::Raw::Zlib::Inflate();my $o;undef $/;$d->inflate(<>,$o);print $o;' | msgpack-cli decode
 ```
 
 ### Runtime Cache

--- a/src/env_diff.rs
+++ b/src/env_diff.rs
@@ -5,8 +5,8 @@ use std::path::{Path, PathBuf};
 
 use base64::prelude::*;
 use color_eyre::eyre::Result;
-use flate2::write::GzDecoder;
-use flate2::write::GzEncoder;
+use flate2::write::ZlibDecoder;
+use flate2::write::ZlibEncoder;
 use flate2::Compression;
 use itertools::Itertools;
 use serde_derive::{Deserialize, Serialize};
@@ -112,7 +112,7 @@ impl EnvDiff {
 
     pub fn deserialize(raw: &str) -> Result<EnvDiff> {
         let mut writer = Vec::new();
-        let mut decoder = GzDecoder::new(writer);
+        let mut decoder = ZlibDecoder::new(writer);
         let bytes = BASE64_STANDARD_NO_PAD.decode(raw)?;
         decoder.write_all(&bytes[..])?;
         writer = decoder.finish()?;
@@ -120,7 +120,7 @@ impl EnvDiff {
     }
 
     pub fn serialize(&self) -> Result<String> {
-        let mut gz = GzEncoder::new(Vec::new(), Compression::fast());
+        let mut gz = ZlibEncoder::new(Vec::new(), Compression::fast());
         gz.write_all(&rmp_serde::to_vec_named(self)?)?;
         Ok(BASE64_STANDARD_NO_PAD.encode(gz.finish()?))
     }

--- a/src/hook_env.rs
+++ b/src/hook_env.rs
@@ -5,8 +5,8 @@ use std::time::SystemTime;
 
 use base64::prelude::*;
 use color_eyre::eyre::Result;
-use flate2::write::GzDecoder;
-use flate2::write::GzEncoder;
+use flate2::write::ZlibDecoder;
+use flate2::write::ZlibEncoder;
 use flate2::Compression;
 
 use crate::config::Config;
@@ -80,14 +80,14 @@ fn have_config_files_been_modified(
 pub type HookEnvWatches = HashMap<PathBuf, SystemTime>;
 
 pub fn serialize_watches(watches: &HookEnvWatches) -> Result<String> {
-    let mut gz = GzEncoder::new(Vec::new(), Compression::fast());
+    let mut gz = ZlibEncoder::new(Vec::new(), Compression::fast());
     gz.write_all(&rmp_serde::to_vec_named(watches)?)?;
     Ok(BASE64_STANDARD_NO_PAD.encode(gz.finish()?))
 }
 
 pub fn deserialize_watches(raw: String) -> Result<HookEnvWatches> {
     let mut writer = Vec::new();
-    let mut decoder = GzDecoder::new(writer);
+    let mut decoder = ZlibDecoder::new(writer);
     let bytes = BASE64_STANDARD_NO_PAD.decode(raw)?;
     decoder.write_all(&bytes[..])?;
     writer = decoder.finish()?;

--- a/src/plugins/cache.rs
+++ b/src/plugins/cache.rs
@@ -1,5 +1,5 @@
-use flate2::read::GzDecoder;
-use flate2::write::GzEncoder;
+use flate2::read::ZlibDecoder;
+use flate2::write::ZlibEncoder;
 use flate2::Compression;
 use serde_derive::{Deserialize, Serialize};
 use std::fs::File;
@@ -16,7 +16,7 @@ pub struct PluginCache {
 impl PluginCache {
     pub fn parse(path: &Path) -> color_eyre::Result<Self> {
         trace!("reading plugin cache from {}", path.to_string_lossy());
-        let mut gz = GzDecoder::new(File::open(path)?);
+        let mut gz = ZlibDecoder::new(File::open(path)?);
         let mut bytes = Vec::new();
         gz.read_to_end(&mut bytes)?;
         Ok(rmp_serde::from_slice(&bytes)?)
@@ -24,7 +24,7 @@ impl PluginCache {
 
     pub fn write(&self, path: &Path) -> color_eyre::Result<()> {
         trace!("writing plugin cache to {}", path.to_string_lossy());
-        let mut gz = GzEncoder::new(File::create(path)?, Compression::fast());
+        let mut gz = ZlibEncoder::new(File::create(path)?, Compression::fast());
         gz.write_all(&rmp_serde::to_vec_named(self)?[..])?;
 
         Ok(())

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -55,7 +55,7 @@ impl Plugin {
         let plugin_path = dirs::PLUGINS.join(name);
         Self {
             name: name.into(),
-            cache_path: plugin_path.join(".rtxcache.msgpack.gz"),
+            cache_path: plugin_path.join(".rtxcache.msgpack"),
             script_man: ScriptManager::new(plugin_path.clone()),
             plugin_path,
             downloads_path: dirs::DOWNLOADS.join(name),


### PR DESCRIPTION
rather than using gzip for plugin cache, nothing for runtimeconf, and zlib for direnv, this makes everything use zlib. I feel like this may have the potential for small performance increases, but it mostly just makes things consistent.

The downside with this is everyone would need to reinstall all of their runtimes, so we'll need to find a way to migrate first.