### PR TITLE
[feat] add Xonsh shell support

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,6 +243,25 @@ $ echo 'eval "$(rtx activate bash)"' >> ~/.bashrc
 $ echo 'rtx activate fish | source' >> ~/.config/fish/config.fish
 ```
 
+### Xonsh
+
+Since `.xsh` files are [not compiled](https://github.com/xonsh/xonsh/issues/3953) you may shave a bit off startup time by using a pure Python import: add the code below to, for example, `~/.config/xonsh/rtx.py` config file and `import rtx` it in `~/.config/xonsh/rc.xsh`:
+```xsh
+from pathlib        	import Path
+from xonsh.built_ins	import XSH
+
+ctx = XSH.ctx
+rtx_init = subprocess.run([Path('~/bin/rtx').expanduser(),'activate','xonsh'],capture_output=True,encoding="UTF-8").stdout
+XSH.builtins.execx(rtx_init,'exec',ctx,filename='rtx')
+```
+
+Or continue to use `rc.xsh`/`.xonshrc`:
+```xsh
+echo 'execx($(~/bin/rtx activate xonsh))' >> ~/.config/xonsh/rc.xsh # or ~/.xonshrc
+```
+
+Given that `rtx` replaces both shell env `$PATH` and OS environ `PATH`, watch out that your configs don't have these two set differently (might throw `os.environ['PATH'] = xonsh.built_ins.XSH.env.get_detyped('PATH')` at the end of a config to make sure they match)
+
 ### Something else?
 
 Adding a new shell is not hard at all since very little shell code is
@@ -490,7 +509,7 @@ Arguments:
   [SHELL_TYPE]
           Shell type to generate the script for
           
-          [possible values: bash, fish, zsh]
+          [possible values: bash, fish, xonsh, zsh]
 
 Options:
   -q, --quiet
@@ -504,6 +523,7 @@ Examples:
     $ eval "$(rtx activate bash)"
     $ eval "$(rtx activate zsh)"
     $ rtx activate fish | source
+    $ execx($(rtx activate xonsh))
 
 ```
 ### `rtx alias ls`
@@ -599,7 +619,7 @@ Arguments:
   [SHELL_TYPE]
           shell type to generate the script for
           
-          [possible values: bash, fish, zsh]
+          [possible values: bash, fish, xonsh, zsh]
 
 Options:
   -h, --help
@@ -610,6 +630,7 @@ Examples:
     $ eval "$(rtx deactivate bash)"
     $ eval "$(rtx deactivate zsh)"
     $ rtx deactivate fish | source
+    $ execx($(rtx deactivate xonsh))
 
 ```
 ### `rtx direnv activate`
@@ -674,7 +695,7 @@ Options:
   -s, --shell <SHELL>
           Shell type to generate environment variables for
           
-          [possible values: bash, fish, zsh]
+          [possible values: bash, fish, xonsh, zsh]
 
   -h, --help
           Print help (see a summary with '-h')
@@ -684,6 +705,7 @@ Examples:
   $ eval "$(rtx env -s bash)"
   $ eval "$(rtx env -s zsh)"
   $ rtx env -s fish | source
+  $ execx($(rtx env -s xonsh))
 
 ```
 ### `rtx exec`

--- a/completions/_rtx
+++ b/completions/_rtx
@@ -33,8 +33,8 @@ _rtx() {
         case $line[1] in
             (activate)
 _arguments "${_arguments_options[@]}" \
-'-s+[Shell type to generate the script for]:SHELL:(bash fish zsh)' \
-'--shell=[Shell type to generate the script for]:SHELL:(bash fish zsh)' \
+'-s+[Shell type to generate the script for]:SHELL:(bash fish xonsh zsh)' \
+'--shell=[Shell type to generate the script for]:SHELL:(bash fish xonsh zsh)' \
 '--log-level=[Set the log output verbosity]:LEVEL: ' \
 '-q[Hide the "rtx: <PLUGIN>@<VERSION>" message when changing directories]' \
 '--quiet[Hide the "rtx: <PLUGIN>@<VERSION>" message when changing directories]' \
@@ -42,7 +42,7 @@ _arguments "${_arguments_options[@]}" \
 '*--verbose[Show installation output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-'::shell_type -- Shell type to generate the script for:(bash fish zsh)' \
+'::shell_type -- Shell type to generate the script for:(bash fish xonsh zsh)' \
 && ret=0
 ;;
 (alias)
@@ -136,14 +136,14 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (deactivate)
 _arguments "${_arguments_options[@]}" \
-'-s+[shell type to generate the script for]:SHELL:(bash fish zsh)' \
-'--shell=[shell type to generate the script for]:SHELL:(bash fish zsh)' \
+'-s+[shell type to generate the script for]:SHELL:(bash fish xonsh zsh)' \
+'--shell=[shell type to generate the script for]:SHELL:(bash fish xonsh zsh)' \
 '--log-level=[Set the log output verbosity]:LEVEL: ' \
 '*-v[Show installation output]' \
 '*--verbose[Show installation output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-'::shell_type -- shell type to generate the script for:(bash fish zsh)' \
+'::shell_type -- shell type to generate the script for:(bash fish xonsh zsh)' \
 && ret=0
 ;;
 (direnv)
@@ -237,8 +237,8 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (env)
 _arguments "${_arguments_options[@]}" \
-'-s+[Shell type to generate environment variables for]:SHELL:(bash fish zsh)' \
-'--shell=[Shell type to generate environment variables for]:SHELL:(bash fish zsh)' \
+'-s+[Shell type to generate environment variables for]:SHELL:(bash fish xonsh zsh)' \
+'--shell=[Shell type to generate environment variables for]:SHELL:(bash fish xonsh zsh)' \
 '--log-level=[Set the log output verbosity]:LEVEL: ' \
 '*-v[Show installation output]' \
 '*--verbose[Show installation output]' \
@@ -274,13 +274,13 @@ _arguments "${_arguments_options[@]}" \
 ;;
 (hook-env)
 _arguments "${_arguments_options[@]}" \
-'-s+[Shell type to generate script for]:SHELL:(bash fish zsh)' \
-'--shell=[Shell type to generate script for]:SHELL:(bash fish zsh)' \
+'-s+[Shell type to generate script for]:SHELL:(bash fish xonsh zsh)' \
+'--shell=[Shell type to generate script for]:SHELL:(bash fish xonsh zsh)' \
 '--log-level=[Set the log output verbosity]:LEVEL: ' \
 '*-v[Show installation output]' \
 '*--verbose[Show installation output]' \
-'-h[Print help (see more with '\''--help'\'')]' \
-'--help[Print help (see more with '\''--help'\'')]' \
+'-h[Print help]' \
+'--help[Print help]' \
 && ret=0
 ;;
 (install)

--- a/completions/rtx.bash
+++ b/completions/rtx.bash
@@ -385,18 +385,18 @@ _rtx() {
             return 0
             ;;
         rtx__activate)
-            opts="-s -q -v -h --shell --quiet --log-level --verbose --help bash fish zsh"
+            opts="-s -q -v -h --shell --quiet --log-level --verbose --help bash fish xonsh zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --shell)
-                    COMPREPLY=($(compgen -W "bash fish zsh" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "bash fish xonsh zsh" -- "${cur}"))
                     return 0
                     ;;
                 -s)
-                    COMPREPLY=($(compgen -W "bash fish zsh" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "bash fish xonsh zsh" -- "${cur}"))
                     return 0
                     ;;
                 --log-level)
@@ -567,18 +567,18 @@ _rtx() {
             return 0
             ;;
         rtx__deactivate)
-            opts="-s -v -h --shell --log-level --verbose --help bash fish zsh"
+            opts="-s -v -h --shell --log-level --verbose --help bash fish xonsh zsh"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
             fi
             case "${prev}" in
                 --shell)
-                    COMPREPLY=($(compgen -W "bash fish zsh" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "bash fish xonsh zsh" -- "${cur}"))
                     return 0
                     ;;
                 -s)
-                    COMPREPLY=($(compgen -W "bash fish zsh" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "bash fish xonsh zsh" -- "${cur}"))
                     return 0
                     ;;
                 --log-level)
@@ -760,11 +760,11 @@ _rtx() {
             fi
             case "${prev}" in
                 --shell)
-                    COMPREPLY=($(compgen -W "bash fish zsh" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "bash fish xonsh zsh" -- "${cur}"))
                     return 0
                     ;;
                 -s)
-                    COMPREPLY=($(compgen -W "bash fish zsh" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "bash fish xonsh zsh" -- "${cur}"))
                     return 0
                     ;;
                 --log-level)
@@ -1366,11 +1366,11 @@ _rtx() {
             fi
             case "${prev}" in
                 --shell)
-                    COMPREPLY=($(compgen -W "bash fish zsh" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "bash fish xonsh zsh" -- "${cur}"))
                     return 0
                     ;;
                 -s)
-                    COMPREPLY=($(compgen -W "bash fish zsh" -- "${cur}"))
+                    COMPREPLY=($(compgen -W "bash fish xonsh zsh" -- "${cur}"))
                     return 0
                     ;;
                 --log-level)

--- a/completions/rtx.fish
+++ b/completions/rtx.fish
@@ -26,7 +26,7 @@ complete -c rtx -n "__fish_use_subcommand" -f -a "version" -d 'Show rtx version'
 complete -c rtx -n "__fish_use_subcommand" -f -a "where" -d 'Display the installation path for a runtime'
 complete -c rtx -n "__fish_use_subcommand" -f -a "render-help" -d 'internal command to generate markdown from help'
 complete -c rtx -n "__fish_use_subcommand" -f -a "help" -d 'Print this message or the help of the given subcommand(s)'
-complete -c rtx -n "__fish_seen_subcommand_from activate" -s s -l shell -d 'Shell type to generate the script for' -r -f -a "{bash	,fish	,zsh	}"
+complete -c rtx -n "__fish_seen_subcommand_from activate" -s s -l shell -d 'Shell type to generate the script for' -r -f -a "{bash	,fish	,xonsh	,zsh	}"
 complete -c rtx -n "__fish_seen_subcommand_from activate" -l log-level -d 'Set the log output verbosity' -r
 complete -c rtx -n "__fish_seen_subcommand_from activate" -s q -l quiet -d 'Hide the "rtx: <PLUGIN>@<VERSION>" message when changing directories'
 complete -c rtx -n "__fish_seen_subcommand_from activate" -s v -l verbose -d 'Show installation output'
@@ -57,7 +57,7 @@ complete -c rtx -n "__fish_seen_subcommand_from complete" -s h -l help -d 'Print
 complete -c rtx -n "__fish_seen_subcommand_from current" -l log-level -d 'Set the log output verbosity' -r
 complete -c rtx -n "__fish_seen_subcommand_from current" -s v -l verbose -d 'Show installation output'
 complete -c rtx -n "__fish_seen_subcommand_from current" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rtx -n "__fish_seen_subcommand_from deactivate" -s s -l shell -d 'shell type to generate the script for' -r -f -a "{bash	,fish	,zsh	}"
+complete -c rtx -n "__fish_seen_subcommand_from deactivate" -s s -l shell -d 'shell type to generate the script for' -r -f -a "{bash	,fish	,xonsh	,zsh	}"
 complete -c rtx -n "__fish_seen_subcommand_from deactivate" -l log-level -d 'Set the log output verbosity' -r
 complete -c rtx -n "__fish_seen_subcommand_from deactivate" -s v -l verbose -d 'Show installation output'
 complete -c rtx -n "__fish_seen_subcommand_from deactivate" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -88,7 +88,7 @@ complete -c rtx -n "__fish_seen_subcommand_from direnv; and __fish_seen_subcomma
 complete -c rtx -n "__fish_seen_subcommand_from doctor" -l log-level -d 'Set the log output verbosity' -r
 complete -c rtx -n "__fish_seen_subcommand_from doctor" -s v -l verbose -d 'Show installation output'
 complete -c rtx -n "__fish_seen_subcommand_from doctor" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rtx -n "__fish_seen_subcommand_from env" -s s -l shell -d 'Shell type to generate environment variables for' -r -f -a "{bash	,fish	,zsh	}"
+complete -c rtx -n "__fish_seen_subcommand_from env" -s s -l shell -d 'Shell type to generate environment variables for' -r -f -a "{bash	,fish	,xonsh	,zsh	}"
 complete -c rtx -n "__fish_seen_subcommand_from env" -l log-level -d 'Set the log output verbosity' -r
 complete -c rtx -n "__fish_seen_subcommand_from env" -s v -l verbose -d 'Show installation output'
 complete -c rtx -n "__fish_seen_subcommand_from env" -s h -l help -d 'Print help (see more with \'--help\')'
@@ -101,10 +101,10 @@ complete -c rtx -n "__fish_seen_subcommand_from global" -l log-level -d 'Set the
 complete -c rtx -n "__fish_seen_subcommand_from global" -l fuzzy -d 'save fuzzy match to .tool-versions e.g.: `rtx global --fuzzy nodejs@20` will save `nodejs 20` to .tool-versions, by default, it would save the exact version, e.g.: `nodejs 20.0.0`'
 complete -c rtx -n "__fish_seen_subcommand_from global" -s v -l verbose -d 'Show installation output'
 complete -c rtx -n "__fish_seen_subcommand_from global" -s h -l help -d 'Print help (see more with \'--help\')'
-complete -c rtx -n "__fish_seen_subcommand_from hook-env" -s s -l shell -d 'Shell type to generate script for' -r -f -a "{bash	,fish	,zsh	}"
+complete -c rtx -n "__fish_seen_subcommand_from hook-env" -s s -l shell -d 'Shell type to generate script for' -r -f -a "{bash	,fish	,xonsh	,zsh	}"
 complete -c rtx -n "__fish_seen_subcommand_from hook-env" -l log-level -d 'Set the log output verbosity' -r
 complete -c rtx -n "__fish_seen_subcommand_from hook-env" -s v -l verbose -d 'Show installation output'
-complete -c rtx -n "__fish_seen_subcommand_from hook-env" -s h -l help -d 'Print help (see more with \'--help\')'
+complete -c rtx -n "__fish_seen_subcommand_from hook-env" -s h -l help -d 'Print help'
 complete -c rtx -n "__fish_seen_subcommand_from install" -s p -l plugin -d 'only install runtime(s) for <PLUGIN>' -r
 complete -c rtx -n "__fish_seen_subcommand_from install" -l log-level -d 'Set the log output verbosity' -r
 complete -c rtx -n "__fish_seen_subcommand_from install" -s f -l force -d 'force reinstall even if already installed'

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -52,6 +52,7 @@ Examples:
     $ eval "$(rtx activate bash)"
     $ eval "$(rtx activate zsh)"
     $ rtx activate fish | source
+    $ execx($(rtx activate xonsh))
 "#;
 
 #[cfg(test)]

--- a/src/cli/deactivate.rs
+++ b/src/cli/deactivate.rs
@@ -36,6 +36,7 @@ Examples:
     $ eval "$(rtx deactivate bash)"
     $ eval "$(rtx deactivate zsh)"
     $ rtx deactivate fish | source
+    $ execx($(rtx deactivate xonsh))
 "#;
 
 #[cfg(test)]

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -51,6 +51,7 @@ Examples:
   $ eval "$(rtx env -s bash)"
   $ eval "$(rtx env -s zsh)"
   $ rtx env -s fish | source
+  $ execx($(rtx env -s xonsh))
 "#;
 
 #[cfg(test)]

--- a/src/cli/hook_env.rs
+++ b/src/cli/hook_env.rs
@@ -19,8 +19,6 @@ use crate::{dirs, env, hook_env};
 #[clap(hide = true)]
 pub struct HookEnv {
     /// Shell type to generate script for
-    ///
-    /// e.g.: bash, zsh, fish
     #[clap(long, short)]
     shell: Option<ShellType>,
 }

--- a/src/cli/render_help.rs
+++ b/src/cli/render_help.rs
@@ -261,6 +261,25 @@ $ echo 'eval "$(rtx activate bash)"' >> ~/.bashrc
 $ echo 'rtx activate fish | source' >> ~/.config/fish/config.fish
 ```
 
+### Xonsh
+
+Since `.xsh` files are [not compiled](https://github.com/xonsh/xonsh/issues/3953) you may shave a bit off startup time by using a pure Python import: add the code below to, for example, `~/.config/xonsh/rtx.py` config file and `import rtx` it in `~/.config/xonsh/rc.xsh`:
+```xsh
+from pathlib        	import Path
+from xonsh.built_ins	import XSH
+
+ctx = XSH.ctx
+rtx_init = subprocess.run([Path('~/bin/rtx').expanduser(),'activate','xonsh'],capture_output=True,encoding="UTF-8").stdout
+XSH.builtins.execx(rtx_init,'exec',ctx,filename='rtx')
+```
+
+Or continue to use `rc.xsh`/`.xonshrc`:
+```xsh
+echo 'execx($(~/bin/rtx activate xonsh))' >> ~/.config/xonsh/rc.xsh # or ~/.xonshrc
+```
+
+Given that `rtx` replaces both shell env `$PATH` and OS environ `PATH`, watch out that your configs don't have these two set differently (might throw `os.environ['PATH'] = xonsh.built_ins.XSH.env.get_detyped('PATH')` at the end of a config to make sure they match)
+
 ### Something else?
 
 Adding a new shell is not hard at all since very little shell code is

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -5,12 +5,14 @@ use crate::env;
 
 mod bash;
 mod fish;
+mod xonsh;
 mod zsh;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, clap::ValueEnum)]
 pub enum ShellType {
     Bash,
     Fish,
+    Xonsh,
     Zsh,
 }
 
@@ -21,6 +23,8 @@ impl ShellType {
             Some(ShellType::Bash)
         } else if shell.ends_with("fish") {
             Some(ShellType::Fish)
+        } else if shell.ends_with("xonsh") {
+            Some(ShellType::Xonsh)
         } else if shell.ends_with("zsh") {
             Some(ShellType::Zsh)
         } else {
@@ -34,6 +38,7 @@ impl Display for ShellType {
         match self {
             Self::Bash => write!(f, "bash"),
             Self::Fish => write!(f, "fish"),
+            Self::Xonsh => write!(f, "xonsh"),
             Self::Zsh => write!(f, "zsh"),
         }
     }
@@ -49,8 +54,9 @@ pub trait Shell {
 pub fn get_shell(shell: Option<ShellType>) -> Box<dyn Shell> {
     match shell.or_else(ShellType::load) {
         Some(ShellType::Bash) => Box::<bash::Bash>::default(),
-        Some(ShellType::Zsh) => Box::<zsh::Zsh>::default(),
         Some(ShellType::Fish) => Box::<fish::Fish>::default(),
+        Some(ShellType::Xonsh) => Box::<xonsh::Xonsh>::default(),
+        Some(ShellType::Zsh) => Box::<zsh::Zsh>::default(),
         _ => panic!("no shell provided, use `--shell=zsh`"),
     }
 }

--- a/src/shell/snapshots/rtx__shell__xonsh__tests__hook_init.snap
+++ b/src/shell/snapshots/rtx__shell__xonsh__tests__hook_init.snap
@@ -1,0 +1,16 @@
+---
+source: src/shell/xonsh.rs
+expression: "Xonsh::default().activate(Path::new(\"/some/dir/rtx\"))"
+---
+from os               import environ
+from xonsh.built_ins  import XSH
+
+envx = XSH.env
+envx['PATH'].add('/some/dir')
+environ['PATH'] = envx.get_detyped('PATH')
+
+def listen_prompt(): # Hook Events
+  execx($(/some/dir/rtx hook-env -s xonsh))
+
+XSH.builtins.events.on_pre_prompt(listen_prompt) # Activate hook: before showing the prompt
+

--- a/src/shell/snapshots/rtx__shell__xonsh__tests__set_env.snap
+++ b/src/shell/snapshots/rtx__shell__xonsh__tests__set_env.snap
@@ -1,0 +1,11 @@
+---
+source: src/shell/xonsh.rs
+expression: "Xonsh::default().set_env(\"FOO\", \"1\")"
+---
+from os               import environ
+from xonsh.built_ins  import XSH
+
+envx = XSH.env
+envx[   'FOO'] = '1'
+environ['FOO'] = envx.get_detyped('FOO')
+

--- a/src/shell/snapshots/rtx__shell__xonsh__tests__unset_env.snap
+++ b/src/shell/snapshots/rtx__shell__xonsh__tests__unset_env.snap
@@ -1,0 +1,11 @@
+---
+source: src/shell/xonsh.rs
+expression: "Xonsh::default().unset_env(\"FOO\")"
+---
+from os               import environ
+from xonsh.built_ins  import XSH
+
+envx = XSH.env
+envx.pop[   'FOO',None]
+environ.pop['FOO',None]
+

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -1,0 +1,142 @@
+use std::path::Path;
+
+use indoc::formatdoc;
+
+use crate::shell::{is_dir_in_path, Shell};
+
+#[derive(Default)]
+pub struct Xonsh {}
+
+use std::borrow::Cow;
+fn xonsh_escape_sq(input: &str) -> Cow<str> {
+    for (i, ch) in input.chars().enumerate() {
+        if xonsh_escape_char(ch).is_some() {
+            let mut escaped_string = String::with_capacity(input.len());
+
+            escaped_string.push_str(&input[..i]);
+            for ch in input[i..].chars() {
+                match xonsh_escape_char(ch) {
+                    Some(escaped_char) => escaped_string.push_str(escaped_char),
+                    None => escaped_string.push(ch),
+                };
+            }
+            return Cow::Owned(escaped_string);
+        }
+    }
+    Cow::Borrowed(input)
+}
+
+fn xonsh_escape_char(ch: char) -> Option<&'static str> {
+    match ch {
+        // escape ' \ ␤ (docs.python.org/3/reference/lexical_analysis.html#strings)
+        '\'' => Some("\\'"),
+        '\\' => Some("\\\\"),
+        '\n' => Some("\\n"),
+        _ => None,
+    }
+}
+
+impl Shell for Xonsh {
+    fn activate(&self, exe: &Path) -> String {
+        let dir = exe.parent().unwrap();
+        let exe = exe.display();
+        let mut out = String::new();
+
+        // todo: xonsh doesn't update the environment that rtx relies on with $PATH.add even with $UPDATE_OS_ENVIRON (github.com/xonsh/xonsh/issues/3207)
+        // with envx.swap(UPDATE_OS_ENVIRON=True): # ← use when ↑ fixed before PATH.add; remove environ
+        // meanwhile, save variables twice: in shell env + in os env
+        // use xonsh API instead of $.xsh to allow use inside of .py configs, which start faster due to being compiled to .pyc
+        out.push_str(&formatdoc! {r#"
+            from os               import environ
+            from xonsh.built_ins  import XSH
+
+        "#});
+        if !is_dir_in_path(dir) {
+            let dir_str = dir.to_string_lossy();
+            let dir_esc = xonsh_escape_sq(&dir_str);
+            out.push_str(&formatdoc! {r#"
+                envx = XSH.env
+                envx['PATH'].add('{dir_esc}')
+                environ['PATH'] = envx.get_detyped('PATH')
+
+            "#});
+        }
+        // todo: subprocess instead of $() is a bit faster, but lose auto-color detection (use $FORCE_COLOR)
+        out.push_str(&formatdoc! {r#"
+            def listen_prompt(): # Hook Events
+              execx($({exe} hook-env -s xonsh))
+
+            XSH.builtins.events.on_pre_prompt(listen_prompt) # Activate hook: before showing the prompt
+            "#});
+
+        out
+    }
+
+    fn deactivate(&self) -> String {
+        formatdoc! {r#"
+            from xonsh.built_ins  import XSH
+
+            hooks = {{
+              'on_pre_prompt' : ['listen_prompt'],
+            }}
+            for   hook_type in hooks:
+              hook_fns = hooks[hook_type]
+              for hook_fn   in hook_fns:
+                hndl = getattr(XSH.builtins.events, hook_type)
+                for fn in hndl:
+                  if fn.__name__ == hook_fn:
+                    hndl.remove(fn)
+                    break
+        "#}
+    }
+
+    fn set_env(&self, k: &str, v: &str) -> String {
+        let k = shell_escape::unix::escape(k.into()); // todo: drop illegal chars, not escape?
+        formatdoc!(
+            r#"
+            from os               import environ
+            from xonsh.built_ins  import XSH
+
+            envx = XSH.env
+            envx[   '{k}'] = '{v}'
+            environ['{k}'] = envx.get_detyped('{k}')
+        "#,
+            k = shell_escape::unix::escape(k), // todo: drop illegal chars, not escape?
+            v = xonsh_escape_sq(v)
+        )
+    }
+
+    fn unset_env(&self, k: &str) -> String {
+        formatdoc!(
+            r#"
+            from os               import environ
+            from xonsh.built_ins  import XSH
+
+            envx = XSH.env
+            envx.pop[   '{k}',None]
+            environ.pop['{k}',None]
+        "#,
+            k = shell_escape::unix::escape(k.into()) // todo: drop illegal chars, not escape?
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_hook_init() {
+        insta::assert_snapshot!(Xonsh::default().activate(Path::new("/some/dir/rtx")));
+    }
+
+    #[test]
+    fn test_set_env() {
+        insta::assert_snapshot!(Xonsh::default().set_env("FOO", "1"));
+    }
+
+    #[test]
+    fn test_unset_env() {
+        insta::assert_snapshot!(Xonsh::default().unset_env("FOO"));
+    }
+}


### PR DESCRIPTION
Seems to be working (it compiles, and since it's Rust, should be fine :)), installed a tool and check entering/exiting a dir with a `.tool-versions` file, did all the contributing list of checks
(though hate that the all the linters hate properly aligned code and turn ↓ tabular beauty into a ziz-zagged mess
```rs
Some(escaped_char) => escaped_string.push_str(escaped_char),
None               => escaped_string.push(ch), // ← cleaner to see the diff vs ↓
```
```rs
Some(escaped_char) => escaped_string.push_str(escaped_char),
None => escaped_string.push(ch),
```
)

Meanwhile, a few questions/comments:
  - var name: I've changed the escape rules for variable values (xonsh uses Python escape rules, not unix shell's), but __NOT__ for variable names — escapes in `$KEY_VAR_with_weird_chars` won't help, it will still result in an error as it's considered an identifier. Don't think anyone would use weird names in variables, but even if they would I think erroring out would be correct as I'm not sure the plugin would expect a silent rename? For now, don't plan to add any fix (and anyway Python has a bunch of identifier rules defined as unicode char groups with some legacy exceptions etc, so didn't want to recreate them from scratch either, do you maybe know a crate that does that?)
  - perf: There is a chance to eek out a ~15% performance on execution when `cd`-ing into a new dir with a `.tool-versions` file (maybe a bit more on new empty dir, but the base is much smaller there), but then you lose autocolor detection (user's would need to use `$FORCE_COLOR` env var to get it back). Worth it?
  - path: I see that you replace the whole `$PATH` every time. This might have a slight negative affect on user configs who have shell `$PATH` different from OS environment `PATH` for one reason or another since both are currently overwritten with values from rtx (shell PATH needs to be overwritten to find `rtx` and other executables, OS `PATH` needs to be overwritte since that's where `rtx` reads info from). Meanwhile, xonsh is capable of adding/removing individual items to/from a `$PATH`. Is this something that `rtx` could pass instead of the wholesale replacement of PATH (afaik you're moving to more granular tracking approach anyway due to a conflict with direnv)?
