### PR TITLE
Fix runtime arg fuzzy matching

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ means there isn't any need to run `asdf reshim` after installing new runtime bin
     rtx local nodejs@20             Use node-20.x in current project
     rtx global nodejs@20            Use node-20.x as default
 
-    rtx install nodejs              Install the latest available version
+    rtx install nodejs              Install the version specified in .tool-versions
     rtx local nodejs@latest         Use latest node in current directory
     rtx global nodejs@system        Use system node as default
 
@@ -829,7 +829,7 @@ Options:
 Examples:
   $ rtx install nodejs@18.0.0  # install specific nodejs version
   $ rtx install nodejs@18      # install fuzzy nodejs version
-  $ rtx install nodejs         # install latest nodejs version—or what is specified in .tool-versions
+  $ rtx install nodejs         # install version specified in .tool-versions
   $ rtx install                # installs all runtimes specified in .tool-versions for installed plugins
   $ rtx install --all          # installs all runtimes and all plugins
 

--- a/completions/_rtx
+++ b/completions/_rtx
@@ -600,7 +600,7 @@ _arguments "${_arguments_options[@]}" \
 '*--verbose[Show installation output]' \
 '-h[Print help (see more with '\''--help'\'')]' \
 '--help[Print help (see more with '\''--help'\'')]' \
-':runtime -- runtime(s) to remove:' \
+':runtime -- runtime(s) to look up if "@<PREFIX>" is specified, it will show the latest installed version that matches the prefix otherwise, it will show the current, active installed version:' \
 '::asdf_version -- the version prefix to use when querying the latest version same as the first argument after the "@" used for asdf compatibility:' \
 && ret=0
 ;;

--- a/src/cli/activate.rs
+++ b/src/cli/activate.rs
@@ -32,6 +32,9 @@ impl Command for Activate {
         let shell = get_shell(self.shell_type.or(self.shell));
 
         if self.quiet {
+            // TODO: it would probably be better to just set --quiet on `hook-env`
+            // this will cause _all_ rtx commands to be quiet, not just the hook
+            // however as of this writing I don't think RTX_QUIET impacts other commands
             rtxprintln!(out, "{}", shell.set_env("RTX_QUIET", "1"));
         }
 

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -82,7 +82,7 @@ mod test {
 
         assert!(stdout.contains(
             dirs::ROOT
-                .join("installs/shfmt/3.5.2/bin")
+                .join("installs/shfmt/3.5.1/bin")
                 .to_string_lossy()
                 .as_ref()
         ));

--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -32,7 +32,7 @@ pub struct Global {
 }
 
 impl Command for Global {
-    fn run(self, config: Config, out: &mut Output) -> Result<()> {
+    fn run(self, mut config: Config, out: &mut Output) -> Result<()> {
         let cf_path = dirs::HOME.join(env::RTX_DEFAULT_TOOL_VERSIONS_FILENAME.as_str());
 
         let mut cf = match cf_path.exists() {
@@ -47,7 +47,7 @@ impl Command for Global {
         }
         if let Some(runtimes) = &self.runtime {
             let runtimes = RuntimeArg::double_runtime_condition(&runtimes.clone());
-            cf.add_runtimes(&config, &runtimes, self.fuzzy)?;
+            cf.add_runtimes(&mut config, &runtimes, self.fuzzy)?;
         }
 
         if self.runtime.is_some() || self.remove.is_some() {

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -37,7 +37,7 @@ pub struct Local {
 }
 
 impl Command for Local {
-    fn run(self, config: Config, out: &mut Output) -> Result<()> {
+    fn run(self, mut config: Config, out: &mut Output) -> Result<()> {
         let cf_path = match self.parent {
             true => file::find_up(
                 &dirs::CURRENT,
@@ -65,7 +65,7 @@ impl Command for Local {
 
         if let Some(runtimes) = &self.runtime {
             let runtimes = RuntimeArg::double_runtime_condition(runtimes);
-            cf.add_runtimes(&config, &runtimes, self.fuzzy)?;
+            cf.add_runtimes(&mut config, &runtimes, self.fuzzy)?;
         }
 
         if self.runtime.is_some() || self.remove.is_some() {

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -174,7 +174,7 @@ const AFTER_HELP: &str = indoc! {"
         rtx local nodejs@20             Use node-20.x in current project
         rtx global nodejs@20            Use node-20.x as default
 
-        rtx install nodejs              Install the latest available version
+        rtx install nodejs              Install the version specified in .tool-versions
         rtx local nodejs                Use latest node in current directory
         rtx global system               Use system node as default
 

--- a/src/cli/render_help.rs
+++ b/src/cli/render_help.rs
@@ -104,7 +104,7 @@ means there isn't any need to run `asdf reshim` after installing new runtime bin
     rtx local nodejs@20             Use node-20.x in current project
     rtx global nodejs@20            Use node-20.x as default
 
-    rtx install nodejs              Install the latest available version
+    rtx install nodejs              Install the version specified in .tool-versions
     rtx local nodejs@latest         Use latest node in current directory
     rtx global nodejs@system        Use system node as default
 


### PR DESCRIPTION
Fixes #119
Fixes #92

This fixes a lot of bugs with the 'runtime arg' which is used throughout rtx. It's the argument used in `rtx local RUNTIMEARG`, `rtx where RUNTIMEARG`, `rtx install RUNTIMEARG`, and many more places.

Originally the intention was for this without an "@" to behave the same as "@latest", but it would _also_ sometimes use the version in `.tool-versions`.

This wasn't consistent throughout rtx and broken in several places that's hard to document fully.

What this change does is make a runtime arg like `nodejs` (without an "@"), look up the current version from `.tool-versions`. `nodejs@latest` will always use the latest available release, despite what may be installed. There were attempts to use the latest _installed_ version to avoid a situation where a new runtime is released and this would require installing it, but for now I'm moving away from that model.

So now things are consistent: `nodejs` means `.tool-versions`. `nodejs@latest` means the latest _available_, not latest _installed_.