### PR TITLE
test: use shfmt@3.5.1

### DIFF
--- a/src/cli/current.rs
+++ b/src/cli/current.rs
@@ -78,7 +78,7 @@ mod test {
     fn test_current() {
         assert_cli!("install");
         let stdout = assert_cli!("current");
-        assert_snapshot!(grep(stdout, "shfmt"), @"shfmt@3.5.2");
+        assert_snapshot!(grep(stdout, "shfmt"), @"shfmt@3.5.1");
     }
 
     #[test]
@@ -86,7 +86,7 @@ mod test {
         assert_cli!("install");
         let stdout = assert_cli!("current", "shfmt");
         assert_snapshot!(stdout, @r###"
-        3.5.2
+        3.5.1
         "###);
     }
 }

--- a/src/cli/direnv/snapshots/rtx__cli__direnv__envrc__test__direnv_envrc.snap
+++ b/src/cli/direnv/snapshots/rtx__cli__direnv__envrc__test__direnv_envrc.snap
@@ -7,7 +7,7 @@ watch_file ~/cwd/.tool-versions
 watch_file ~/cwd/.node-version
 watch_file ~/.tool-versions
 export JDXCODE_TINY=2.1.0
-PATH_add ~/data/installs/shfmt/3.5.2/bin
+PATH_add ~/data/installs/shfmt/3.5.1/bin
 PATH_add ~/data/installs/jq/1.6/bin
 PATH_add ~/data/installs/tiny/2.1.0/bin
 PATH_add ~/data/installs/shellcheck/0.9.0/bin

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -68,7 +68,7 @@ mod test {
         let stdout = assert_cli!("env", "-s", "bash");
         assert!(stdout.contains(
             dirs::ROOT
-                .join("installs/shfmt/3.5.2/bin")
+                .join("installs/shfmt/3.5.1/bin")
                 .to_string_lossy()
                 .as_ref()
         ));

--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -160,9 +160,9 @@ mod test {
         let re = Regex::new(r" {3}shfmt\s+3\.5\.0\s+").unwrap();
         assert!(re.is_match(&stdout));
 
-        assert_cli!("uninstall", "shfmt@3.5.2");
+        assert_cli!("uninstall", "shfmt@3.5.1");
         let stdout = assert_cli!("list");
-        let re = Regex::new(r" {3}shfmt\s+3\.5\.2 \(missing\)\s+").unwrap();
+        let re = Regex::new(r" {3}shfmt\s+3\.5\.1 \(missing\)\s+").unwrap();
         assert!(re.is_match(&stdout));
     }
 }

--- a/src/cli/where.rs
+++ b/src/cli/where.rs
@@ -74,7 +74,7 @@ mod test {
         let stdout = assert_cli!("where", "shfmt");
         assert_str_eq!(
             stdout.trim(),
-            dirs::ROOT.join("installs/shfmt/3.5.2").to_string_lossy()
+            dirs::ROOT.join("installs/shfmt/3.5.1").to_string_lossy()
         );
     }
 

--- a/src/config/config_file/tool_versions.rs
+++ b/src/config/config_file/tool_versions.rs
@@ -189,7 +189,7 @@ pub(crate) mod tests {
     fn test_parse() {
         let tv = ToolVersions::from_file(dirs::CURRENT.join(".tool-versions").as_path()).unwrap();
         assert_eq!(tv.path, dirs::CURRENT.join(".tool-versions"));
-        assert_display_snapshot!(tv, @"ToolVersions(~/cwd/.tool-versions): shellcheck@0.9.0, shfmt@3.5.2, nodejs@system");
+        assert_display_snapshot!(tv, @"ToolVersions(~/cwd/.tool-versions): shellcheck@0.9.0, shfmt@3.5.1, nodejs@system");
     }
 
     #[test]

--- a/test/cwd/.tool-versions
+++ b/test/cwd/.tool-versions
@@ -1,5 +1,5 @@
 #python 3.11.1 3.10.9 # foo
 shellcheck 0.9.0
-shfmt 3.5.2 # test comment
+shfmt 3.5.1 # test comment
 #nodejs 18.13.0
 nodejs system


### PR DESCRIPTION
shfmt@3.5.2 does not exist but because the plugin did not fail on invalid versions, it behaved as if it did. This uses a real version of shfmt