### PR TITLE
bug: fix semver version sorting

### DIFF
--- a/src/cli/ls.rs
+++ b/src/cli/ls.rs
@@ -6,7 +6,7 @@ use std::sync::Arc;
 use color_eyre::eyre::Result;
 use itertools::Itertools;
 use owo_colors::{OwoColorize, Stream};
-use versions::Mess;
+use versions::Versioning;
 
 use crate::cli::command::Command;
 use crate::config::{Config, PluginSource};
@@ -118,7 +118,7 @@ fn get_runtime_list(
     let rvs: Vec<(Arc<RuntimeVersion>, Option<PluginSource>)> = versions
         .into_iter()
         .sorted_by_cached_key(|((plugin_name, version), _)| {
-            (plugin_name.clone(), Mess::new(version).unwrap_or_default())
+            (plugin_name.clone(), Versioning::new(version))
         })
         .map(|(k, rtv)| {
             let source = match &active.get(&k) {

--- a/src/config/toolset.rs
+++ b/src/config/toolset.rs
@@ -5,7 +5,7 @@ use color_eyre::eyre::Result;
 use indexmap::IndexMap;
 use itertools::Itertools;
 use rayon::prelude::*;
-use versions::Mess;
+use versions::Versioning;
 
 use crate::config::{AliasMap, PluginSource};
 use crate::plugins::{Plugin, PluginName};
@@ -191,7 +191,7 @@ impl Toolset {
             }
             let sorted_versions = installed_versions
                 .keys()
-                .sorted_by_cached_key(|v| v.parse::<Mess>().unwrap())
+                .sorted_by_cached_key(|v| Versioning::new(v))
                 .rev()
                 .collect::<Vec<_>>();
             for v in sorted_versions {

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -10,7 +10,7 @@ use color_eyre::eyre::{eyre, Result};
 use itertools::Itertools;
 use lazy_static::lazy_static;
 use regex::Regex;
-use versions::Mess;
+use versions::Versioning;
 
 use cache::PluginCache;
 pub use script_manager::{InstallType, Script, ScriptManager};
@@ -216,7 +216,7 @@ impl Plugin {
         Ok(match self.installs_path.exists() {
             true => file::dir_subdirs(&self.installs_path)?
                 .iter()
-                .map(|v| Mess::new(v).unwrap())
+                .map(|v| Versioning::new(v).unwrap_or_default())
                 .sorted()
                 .map(|v| v.to_string())
                 .collect(),

--- a/src/runtimes/mod.rs
+++ b/src/runtimes/mod.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 
 use color_eyre::eyre::{eyre, Result, WrapErr};
 use owo_colors::{OwoColorize, Stream};
+use versions::Versioning;
 
 use runtime_conf::RuntimeConf;
 
@@ -63,7 +64,7 @@ impl RuntimeVersion {
                 versions.push(Self::new(plugin.clone(), &version));
             }
         }
-        versions.sort_by_cached_key(|rtv| versions::Mess::new(rtv.version.as_str()));
+        versions.sort_by_cached_key(|rtv| Versioning::new(rtv.version.as_str()));
         Ok(versions)
     }
 


### PR DESCRIPTION
Fixes #119

turns out `Mess` doesn't work the way I thought it did, it looks like it basically just does an alphabetic sort, not semver sort. This makes the versions sorted correctly.

Before:
```
$ rtx ls
-> golang 1.19.5             (set by ~/.tool-versions)
-> hadolint 2.10.0           (set by ~/.tool-versions)
-> java openjdk-19.0.2       (set by ~/.tool-versions)
-> jq 1.6                    (set by ~/src/rtx/.tool-versions)
-> nodejs 18.13.0            (set by ~/src/rtx/.node-version)
-> python 3.10.10            (set by ~/.tool-versions)
   python 3.10.9
   python 3.11.1
-> python 3.11.2             (set by ~/.tool-versions)
```

After:

```
$ rtx ls
   bun 0.5.6
-> golang 1.19.5             (set by ~/.tool-versions)
-> hadolint 2.10.0           (set by ~/.tool-versions)
-> java openjdk-19.0.2       (set by ~/.tool-versions)
-> jq 1.6                    (set by ~/src/rtx/.tool-versions)
-> nodejs 18.13.0            (set by ~/src/rtx/.node-version)
   python 3.10.9
-> python 3.10.10            (set by ~/.tool-versions)
   python 3.11.1
-> python 3.11.2             (set by ~/.tool-versions)
-> ruby 3.2.0                (set by ~/.tool-versions)
-> rust 1.67.0               (set by ~/.tool-versions)
-> shellcheck 0.9.0          (set by ~/src/rtx/.tool-versions)
   shfmt 2.6.4
   shfmt 3.4.3
   shfmt 3.5.1
   shfmt 3.5.2
-> shfmt 3.6.0               (set by ~/src/rtx/.tool-versions)
```

(note python@3.10)