### PR TITLE
bug: ensure `rtx version` works even if config loading fails

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -33,7 +33,7 @@ mod ls_remote;
 mod plugins;
 mod settings;
 mod uninstall;
-mod version;
+pub mod version;
 mod r#where;
 
 // render help

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -38,14 +38,27 @@ pub static VERSION: Lazy<String> = Lazy::new(|| {
 
 impl Command for Version {
     fn run(self, _config: Config, out: &mut Output) -> Result<()> {
-        let v = VERSION.to_string();
-        rtxprintln!(out, "{v}");
+        show_version(out);
         Ok(())
     }
 }
 
+pub fn print_version_if_requested(args: &[String], out: &mut Output) {
+    if args.len() == 2 {
+        let cmd = &args[1].to_lowercase();
+        if cmd == "version" || cmd == "-v" || cmd == "--version" {
+            show_version(out);
+            std::process::exit(0);
+        }
+    }
+}
+
+fn show_version(out: &mut Output) {
+    rtxprintln!(out, "{}", *VERSION);
+}
+
 #[cfg(test)]
-mod tests {
+mod test {
     use pretty_assertions::assert_str_eq;
 
     use crate::assert_cli;


### PR DESCRIPTION
This also adds the version to error messages and makes it so config loading will show a friendlier error message unless RTX_DEBUG=1 is set.

Fixes #102 