### PR TITLE
feat: ref/path/prefix support

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,10 +315,13 @@ The `.tool-versions` file is used to specify the runtime versions for a project.
 is:
 
 ```
-nodejs      20.0.0  # comments are allowed
-ruby        3       # can be fuzzy version
-shellcheck  latest  # also supports "latest"
+nodejs      20.0.0       # comments are allowed
+ruby        3            # can be fuzzy version
+shellcheck  latest       # also supports "latest"
 jq          1.6
+erlang      ref:master   # compile from vcs ref
+golang      prefix:1.19  # uses the latest 1.19.x version—needed in case "1.19" is an exact match
+shfmt       path:./shfmt # use a custom runtime
 ```
 
 Create `.tool-versions` files manually, or use [`rtx local`](#rtx-local) to create them automatically.

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -127,7 +127,8 @@ static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
 
 #[cfg(test)]
 mod tests {
-    use crate::assert_cli;
+    use crate::{assert_cli, dirs};
+    use pretty_assertions::assert_str_eq;
 
     #[test]
     fn test_install_force() {
@@ -143,5 +144,16 @@ mod tests {
     fn test_install_with_alias() {
         assert_cli!("install", "-f", "shfmt@my/alias");
         assert_cli!("where", "shfmt@my/alias");
+    }
+
+    #[test]
+    fn test_install_ref() {
+        assert_cli!("install", "-f", "dummy@ref:master");
+        assert_cli!("global", "dummy@ref:master");
+        let output = assert_cli!("where", "dummy");
+        assert_str_eq!(
+            output.trim(),
+            dirs::INSTALLS.join("dummy/ref-master").to_string_lossy()
+        );
     }
 }

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -149,6 +149,18 @@ mod tests {
         let stdout = assert_cli!("local", "--pin", "tiny", "2");
         assert_str_eq!(grep(stdout, "tiny"), "tiny 2.1.0");
 
+        // path
+        let stdout = assert_cli!("local", "dummy@path:.");
+        assert_str_eq!(grep(stdout, "dummy"), "dummy path:.");
+
+        // ref
+        let stdout = assert_cli!("local", "dummy@ref:master");
+        assert_str_eq!(grep(stdout, "dummy"), "dummy ref:master");
+
+        // prefix
+        let stdout = assert_cli!("local", "dummy@prefix:1");
+        assert_str_eq!(grep(stdout, "dummy"), "dummy prefix:1");
+
         // will output the current version(s)
         let stdout = assert_cli!("local", "tiny");
         assert_str_eq!(stdout, "2.1.0\n");

--- a/src/cli/render_help.rs
+++ b/src/cli/render_help.rs
@@ -334,10 +334,13 @@ The `.tool-versions` file is used to specify the runtime versions for a project.
 is:
 
 ```
-nodejs      20.0.0  # comments are allowed
-ruby        3       # can be fuzzy version
-shellcheck  latest  # also supports "latest"
+nodejs      20.0.0       # comments are allowed
+ruby        3            # can be fuzzy version
+shellcheck  latest       # also supports "latest"
 jq          1.6
+erlang      ref:master   # compile from vcs ref
+golang      prefix:1.19  # uses the latest 1.19.x version—needed in case "1.19" is an exact match
+shfmt       path:./shfmt # use a custom runtime
 ```
 
 Create `.tool-versions` files manually, or use [`rtx local`](#rtx-local) to create them automatically.

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -63,8 +63,11 @@ impl dyn ConfigFile {
                     .push(if pin {
                         rtv.version.to_string()
                     } else {
-                        match runtime.version {
+                        match &runtime.version {
                             RuntimeArgVersion::Version(ref v) => v.to_string(),
+                            RuntimeArgVersion::Path(p) => format!("path:{p}"),
+                            RuntimeArgVersion::Ref(r) => format!("ref:{r}"),
+                            RuntimeArgVersion::Prefix(p) => format!("prefix:{p}"),
                             _ => "latest".to_string(),
                         }
                     });

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -1,9 +1,9 @@
 use std::collections::HashMap;
-use std::fmt;
 use std::fmt::{Display, Formatter};
-use std::fs::{create_dir_all, remove_dir_all};
+use std::fs::{create_dir_all, remove_dir_all, File};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::{fmt, fs};
 
 use color_eyre::eyre::{Result, WrapErr};
 use console::style;
@@ -14,6 +14,7 @@ use crate::cache::CacheManager;
 use crate::config::Config;
 use crate::config::Settings;
 use crate::env_diff::{EnvDiff, EnvDiffOperation};
+use crate::hash::hash_to_str;
 use crate::plugins::{InstallType, Plugin, Script, ScriptManager};
 use crate::ui::progress_report::ProgressReport;
 use crate::{dirs, env, fake_asdf, file};
@@ -25,38 +26,44 @@ pub struct RuntimeVersion {
     pub version: String,
     pub plugin: Arc<Plugin>,
     pub install_path: PathBuf,
+    pub install_type: InstallType,
     download_path: PathBuf,
     script_man: ScriptManager,
     bin_paths_cache: CacheManager<Vec<String>>,
 }
 
 impl RuntimeVersion {
-    pub fn new(plugin: Arc<Plugin>, version: &str) -> Self {
-        let install_path = dirs::INSTALLS.join(&plugin.name).join(version);
-        let download_path = dirs::DOWNLOADS.join(&plugin.name).join(version);
-        let cache_path = dirs::CACHE.join(&plugin.name).join(version);
+    pub fn new(plugin: Arc<Plugin>, install_type: InstallType) -> Self {
+        let version = match &install_type {
+            InstallType::Version(v) => v.to_string(),
+            InstallType::Ref(r) => format!("ref-{r}"),
+            InstallType::Path(p) => hash_to_str(&p),
+            InstallType::System => "system".into(),
+        };
+        let install_path = match &install_type {
+            InstallType::Path(p) => p.clone(),
+            _ => dirs::INSTALLS.join(&plugin.name).join(&version),
+        };
+        let download_path = dirs::DOWNLOADS.join(&plugin.name).join(&version);
+        let cache_path = dirs::CACHE.join(&plugin.name).join(&version);
         Self {
             script_man: build_script_man(
-                version,
+                install_type.clone(),
                 &plugin.plugin_path,
                 &install_path,
                 &download_path,
             ),
             bin_paths_cache: CacheManager::new(cache_path.join("bin_paths.msgpack.zlib"))
                 .with_fresh_file(install_path.clone()),
-            download_path: dirs::DOWNLOADS.join(&plugin.name).join(version),
+            download_path,
             install_path,
-            version: version.into(),
+            version,
             plugin,
+            install_type,
         }
     }
 
-    pub fn install(
-        &self,
-        install_type: InstallType,
-        config: &Config,
-        mut pr: ProgressReport,
-    ) -> Result<()> {
+    pub fn install(&self, config: &Config, mut pr: ProgressReport) -> Result<()> {
         static PROG_TEMPLATE: Lazy<ProgressStyle> = Lazy::new(|| {
             ProgressStyle::with_template("{prefix}{wide_msg} {spinner:.blue} {elapsed:.dim.italic}")
                 .unwrap()
@@ -70,11 +77,11 @@ impl RuntimeVersion {
         pr.enable_steady_tick();
 
         let settings = &config.settings;
-        debug!("install {} {}", self, install_type);
+        debug!("install {} {}", self, self.install_type);
 
         self.create_install_dirs()?;
-        let download = Script::Download(install_type.clone());
-        let install = Script::Install(install_type);
+        let download = Script::Download(self.install_type.clone());
+        let install = Script::Install(self.install_type.clone());
 
         let run_script = |script| {
             self.script_man.run_by_line(
@@ -109,6 +116,9 @@ impl RuntimeVersion {
                 debug!("error touching config file: {:?} {:?}", path, err);
             }
         }
+        if let Err(err) = fs::remove_file(self.incomplete_file_path()) {
+            debug!("error removing .rtx-incomplete: {:?}", err);
+        }
         pr.finish_with_message(style("✓").green().for_stderr().to_string());
 
         Ok(())
@@ -124,10 +134,13 @@ impl RuntimeVersion {
     }
 
     pub fn is_installed(&self) -> bool {
-        if self.version == "system" {
-            return true;
+        match &self.install_type {
+            InstallType::System => true,
+            InstallType::Path(p) => p.exists(),
+            InstallType::Version(_) | InstallType::Ref(_) => {
+                self.install_path.exists() && !self.incomplete_file_path().exists()
+            }
         }
-        self.install_path.exists()
     }
 
     pub fn uninstall(&self) -> Result<()> {
@@ -190,6 +203,7 @@ impl RuntimeVersion {
         let _ = remove_dir_all(&self.download_path);
         create_dir_all(&self.install_path)?;
         create_dir_all(&self.download_path)?;
+        File::create(self.incomplete_file_path())?;
         Ok(())
     }
 
@@ -201,6 +215,10 @@ impl RuntimeVersion {
         if !settings.always_keep_download {
             let _ = remove_dir_all(&self.download_path);
         }
+    }
+
+    fn incomplete_file_path(&self) -> PathBuf {
+        self.install_path.join(".rtx-incomplete")
     }
 }
 
@@ -217,15 +235,14 @@ impl PartialEq for RuntimeVersion {
 }
 
 fn build_script_man(
-    version: &str,
+    install_type: InstallType,
     plugin_path: &Path,
     install_path: &Path,
     download_path: &Path,
 ) -> ScriptManager {
-    ScriptManager::new(plugin_path.to_path_buf())
+    let sm = ScriptManager::new(plugin_path.to_path_buf())
         .with_envs(env::PRISTINE_ENV.clone())
         .with_env("PATH".into(), fake_asdf::get_path_with_fake_asdf())
-        .with_env("ASDF_INSTALL_VERSION".into(), version.to_string())
         .with_env(
             "ASDF_INSTALL_PATH".into(),
             install_path.to_string_lossy().to_string(),
@@ -234,5 +251,14 @@ fn build_script_man(
             "ASDF_DOWNLOAD_PATH".into(),
             download_path.to_string_lossy().to_string(),
         )
-        .with_env("ASDF_CONCURRENCY".into(), num_cpus::get().to_string())
+        .with_env("ASDF_CONCURRENCY".into(), num_cpus::get().to_string());
+    match install_type {
+        InstallType::Version(v) => sm
+            .with_env("ASDF_INSTALL_TYPE".into(), "version".into())
+            .with_env("ASDF_INSTALL_VERSION".into(), v),
+        InstallType::Ref(r) => sm
+            .with_env("ASDF_INSTALL_TYPE".into(), "ref".into())
+            .with_env("ASDF_INSTALL_VERSION".into(), r),
+        _ => sm,
+    }
 }

--- a/src/toolset/builder.rs
+++ b/src/toolset/builder.rs
@@ -108,6 +108,21 @@ fn load_runtime_args(ts: &mut Toolset, args: &[RuntimeArg]) {
                         ToolVersion::new(plugin_name.clone(), ToolVersionType::Version(v.clone()));
                     arg_ts.add_version(plugin_name.clone(), version);
                 }
+                RuntimeArgVersion::Ref(ref v) => {
+                    let version =
+                        ToolVersion::new(plugin_name.clone(), ToolVersionType::Ref(v.clone()));
+                    arg_ts.add_version(plugin_name.clone(), version);
+                }
+                RuntimeArgVersion::Path(ref v) => {
+                    let version =
+                        ToolVersion::new(plugin_name.clone(), ToolVersionType::Path(v.clone()));
+                    arg_ts.add_version(plugin_name.clone(), version);
+                }
+                RuntimeArgVersion::Prefix(ref v) => {
+                    let version =
+                        ToolVersion::new(plugin_name.clone(), ToolVersionType::Prefix(v.clone()));
+                    arg_ts.add_version(plugin_name.clone(), version);
+                }
                 // I believe this will do nothing since it would just default to the `.tool-versions` version
                 // RuntimeArgVersion::None => {
                 //     arg_ts.add_version(plugin_name.clone(), ToolVersion::None);

--- a/src/toolset/tool_version_list.rs
+++ b/src/toolset/tool_version_list.rs
@@ -1,6 +1,7 @@
 use crate::config::Settings;
 use crate::plugins::Plugin;
 use crate::runtimes::RuntimeVersion;
+use std::sync::Arc;
 
 use crate::toolset::{ToolSource, ToolVersion};
 
@@ -21,9 +22,9 @@ impl ToolVersionList {
     pub fn add_version(&mut self, version: ToolVersion) {
         self.versions.push(version);
     }
-    pub fn resolve(&mut self, settings: &Settings, plugin: &Plugin) {
+    pub fn resolve(&mut self, settings: &Settings, plugin: Arc<Plugin>) {
         for tv in &mut self.versions {
-            if let Err(err) = tv.resolve(settings, plugin) {
+            if let Err(err) = tv.resolve(settings, plugin.clone()) {
                 warn!("failed to resolve tool version: {}", err);
             }
         }


### PR DESCRIPTION
Fixes #98
Fixes #120

`ref:` lets you specify a git sha to download
`path:` lets you use a custom runtime directory
`prefix:` forces prefix matching (so you can do `golang@prefix:1.19` to match any "go1.19*" version