### PR TITLE
chore: added self-update feature

### DIFF
--- a/.bin/rtx
+++ b/.bin/rtx
@@ -5,4 +5,4 @@ set -e
 # when chims are called in shebangs
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cargo run --manifest-path "$SCRIPT_DIR/../Cargo.toml" -- "$@"
+cargo run --all-features --manifest-path "$SCRIPT_DIR/../Cargo.toml" -- "$@"

--- a/.github/workflows/rtx.yml
+++ b/.github/workflows/rtx.yml
@@ -84,7 +84,7 @@ jobs:
         with:
           use-cross: true
           command: build
-          args: --release --target ${{matrix.target}}
+          args: --release --all-features --target ${{matrix.target}}
       - run: scripts/build-tarball.sh ${{matrix.target}}
       - uses: actions/upload-artifact@v3
         with:
@@ -113,7 +113,7 @@ jobs:
       - name: Rust Cache
         uses: Swatinem/rust-cache@v2
         with: { key: "${{matrix.target}}" }
-      - run: cargo build --release --target ${{matrix.target}}
+      - run: cargo build --release --all-features --target ${{matrix.target}}
       - run: scripts/build-tarball.sh ${{matrix.target}}
       - uses: actions/upload-artifact@v3
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ rayon = "1.6.1"
 regex = "1.7.1"
 reqwest = { version = "0.11.14", features = ["blocking"] }
 rmp-serde = "1.1.1"
-self_update = "0.35.0"
+self_update = { version = "0.35.0", optional = true }
 serde = "1.0.152"
 serde_derive = "1.0.152"
 serde_json = "1.0.92"

--- a/src/build_time.rs
+++ b/src/build_time.rs
@@ -2,7 +2,7 @@ use crate::env::RTX_HIDE_OUTDATED_BUILD;
 use build_time::build_time_utc;
 use chrono::{DateTime, FixedOffset, Months, Utc};
 use console::style;
-use indoc::eprintdoc;
+
 use lazy_static::lazy_static;
 
 lazy_static! {
@@ -15,13 +15,13 @@ fn init() {
     if !*RTX_HIDE_OUTDATED_BUILD
         && BUILD_TIME.checked_add_months(Months::new(12)).unwrap() < Utc::now()
     {
-        eprintdoc!(
-            "
-            {rtx} rtx has not been updated in over a year.
-            {rtx} Please update to the latest version, update with: `rtx self-update`
-            {rtx} To hide this warning, set RTX_HIDE_OUTDATED_BUILD=1.
-            ",
-            rtx = style("rtx").dim().for_stderr()
+        let rtx = style("rtx").dim().for_stderr();
+        eprintln!(
+            "{rtx} rtx has not been updated in over a year. Please update to the latest version"
         );
+        if cfg!(feature = "self_update") {
+            eprintln!("{rtx} update with: `rtx self-update`");
+        }
+        eprintln!("{rtx} To hide this warning, set RTX_HIDE_OUTDATED_BUILD=1.");
     }
 }

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -32,7 +32,6 @@ mod local;
 mod ls;
 mod ls_remote;
 mod plugins;
-mod self_update;
 mod settings;
 mod uninstall;
 pub mod version;
@@ -41,6 +40,9 @@ mod r#where;
 // render help
 #[cfg(debug_assertions)]
 mod render_help;
+
+#[cfg(feature = "self_update")]
+mod self_update;
 
 pub struct Cli {
     command: clap::Command,
@@ -68,6 +70,7 @@ pub enum Commands {
     Ls(ls::Ls),
     LsRemote(ls_remote::LsRemote),
     Plugins(plugins::Plugins),
+    #[cfg(feature = "self_update")]
     SelfUpdate(self_update::SelfUpdate),
     Settings(settings::Settings),
     Uninstall(uninstall::Uninstall),
@@ -100,6 +103,7 @@ impl Commands {
             Self::Ls(cmd) => cmd.run(config, out),
             Self::LsRemote(cmd) => cmd.run(config, out),
             Self::Plugins(cmd) => cmd.run(config, out),
+            #[cfg(feature = "self_update")]
             Self::SelfUpdate(cmd) => cmd.run(config, out),
             Self::Settings(cmd) => cmd.run(config, out),
             Self::Uninstall(cmd) => cmd.run(config, out),


### PR DESCRIPTION
This will allow me to only enable self-update when
building non-package manager CLIs
