### PR TITLE
refactor: clean up rtxrc editing

### DIFF
--- a/src/cli/alias/set.rs
+++ b/src/cli/alias/set.rs
@@ -24,9 +24,9 @@ pub struct AliasSet {
 
 impl Command for AliasSet {
     fn run(self, config: Config, _out: &mut Output) -> Result<()> {
-        let mut rtxrc = config.rtxrc;
+        let rtxrc = config.rtxrc;
 
-        rtxrc.set_alias(&self.plugin, &self.alias, &self.value);
+        rtxrc.set_alias(&self.plugin, &self.alias, &self.value)?;
         rtxrc.save()
     }
 }

--- a/src/cli/alias/unset.rs
+++ b/src/cli/alias/unset.rs
@@ -22,8 +22,8 @@ pub struct AliasUnset {
 
 impl Command for AliasUnset {
     fn run(self, config: Config, _out: &mut Output) -> Result<()> {
-        let mut rtxrc = config.rtxrc;
-        rtxrc.remove_alias(&self.plugin, &self.alias);
+        let rtxrc = config.rtxrc;
+        rtxrc.remove_alias(&self.plugin, &self.alias)?;
         rtxrc.save()
     }
 }

--- a/src/cli/settings/set.rs
+++ b/src/cli/settings/set.rs
@@ -22,7 +22,7 @@ pub struct SettingsSet {
 
 impl Command for SettingsSet {
     fn run(self, config: Config, _out: &mut Output) -> Result<()> {
-        let mut rtxrc = config.rtxrc;
+        let rtxrc = config.rtxrc;
         let value: toml_edit::Value = match self.key.as_str() {
             "missing_runtime_behavior" => self.value.into(),
             "always_keep_download" => parse_bool(&self.value)?,
@@ -32,7 +32,7 @@ impl Command for SettingsSet {
             _ => return Err(eyre!("Unknown setting: {}", self.key)),
         };
 
-        rtxrc.update_setting(&self.key, value);
+        rtxrc.update_setting(&self.key, value)?;
         rtxrc.save()
     }
 }

--- a/src/cli/settings/unset.rs
+++ b/src/cli/settings/unset.rs
@@ -20,8 +20,8 @@ pub struct SettingsUnset {
 
 impl Command for SettingsUnset {
     fn run(self, config: Config, _out: &mut Output) -> Result<()> {
-        let mut rtxrc = config.rtxrc;
-        rtxrc.remove_setting(&self.key);
+        let rtxrc = config.rtxrc;
+        rtxrc.remove_setting(&self.key)?;
         rtxrc.save()
     }
 }


### PR DESCRIPTION
This uses a OnceCell to help with creating the editable document and memoizing it. It also uses a Mutex which reduces the need to making things mutable. I was using `get_edit()` and `get_or_init_edit()` as a memoizeable and non-memoizable methods, this makes it so `get_edit()` is memoized and doesn't require a mutable reference to Rtxrc

cc @roele 