### PR TITLE
bug: allow specifying ref/path as an alias

### DIFF
--- a/src/cli/args/runtime.rs
+++ b/src/cli/args/runtime.rs
@@ -93,14 +93,7 @@ impl RuntimeArg {
 
 impl Display for RuntimeArg {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.version {
-            RuntimeArgVersion::System => write!(f, "{}@system", self.plugin),
-            RuntimeArgVersion::Path(path) => write!(f, "{}@path:{}", self.plugin, path),
-            RuntimeArgVersion::Version(version) => write!(f, "{}@{}", self.plugin, version),
-            RuntimeArgVersion::Ref(ref_) => write!(f, "{}@ref:{}", self.plugin, ref_),
-            RuntimeArgVersion::Prefix(prefix) => write!(f, "{}@prefix:{}", self.plugin, prefix),
-            RuntimeArgVersion::None => write!(f, "{}", self.plugin),
-        }
+        write!(f, "{}@{}", self.plugin, self.version)
     }
 }
 

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -166,6 +166,34 @@ mod tests {
         let err = assert_cli_err!("local", "tiny", "dummy@latest");
         assert_str_eq!(err.to_string(), "invalid input, specify a version for each runtime. Or just specify one runtime to print the current version");
 
+        // alias ref
+        assert_cli!("alias", "set", "dummy", "m", "ref:master");
+        let stdout = assert_cli!("local", "dummy@m");
+        assert_str_eq!(grep(stdout, "dummy"), "dummy m");
+        assert_cli_snapshot!("current", "dummy");
+
+        // alias path
+        let local_dummy_path = dirs::INSTALLS.join("dummy").join("1.1.0");
+        let path_arg = String::from("path:") + &local_dummy_path.to_string_lossy();
+        assert_cli!("alias", "set", "dummy", "m", &path_arg);
+        let stdout = assert_cli!("local", "dummy@m");
+        assert_str_eq!(grep(stdout, "dummy"), "dummy m");
+        let stdout = assert_cli!("current", "dummy");
+        assert_str_eq!(grep(stdout, "dummy"), "~/data/installs/dummy/1.1.0");
+
+        // alias prefix
+        assert_cli!("alias", "set", "dummy", "m", "prefix:1");
+        let stdout = assert_cli!("local", "dummy@m");
+        assert_str_eq!(grep(stdout, "dummy"), "dummy m");
+        assert_cli_snapshot!("current", "dummy");
+
+        // alias system
+        assert_cli!("alias", "set", "dummy", "m", "system");
+        let stdout = assert_cli!("local", "dummy@m");
+        assert_str_eq!(grep(stdout, "dummy"), "dummy m");
+        assert_cli_snapshot!("current", "dummy");
+
+        assert_cli!("alias", "unset", "dummy", "m");
         fs::write(cf_path, orig).unwrap();
     }
 }

--- a/src/cli/snapshots/rtx__cli__local__tests__local-4.snap
+++ b/src/cli/snapshots/rtx__cli__local__tests__local-4.snap
@@ -1,0 +1,6 @@
+---
+source: src/cli/local.rs
+expression: output
+---
+ref-master
+

--- a/src/cli/snapshots/rtx__cli__local__tests__local-5.snap
+++ b/src/cli/snapshots/rtx__cli__local__tests__local-5.snap
@@ -1,0 +1,6 @@
+---
+source: src/cli/local.rs
+expression: output
+---
+1.1.0
+

--- a/src/cli/snapshots/rtx__cli__local__tests__local-6.snap
+++ b/src/cli/snapshots/rtx__cli__local__tests__local-6.snap
@@ -1,0 +1,6 @@
+---
+source: src/cli/local.rs
+expression: output
+---
+system
+

--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -37,15 +37,21 @@ impl RuntimeVersion {
         let version = match &install_type {
             InstallType::Version(v) => v.to_string(),
             InstallType::Ref(r) => format!("ref-{r}"),
-            InstallType::Path(p) => hash_to_str(&p),
+            InstallType::Path(p) => p.display().to_string(),
             InstallType::System => "system".into(),
         };
         let install_path = match &install_type {
             InstallType::Path(p) => p.clone(),
             _ => dirs::INSTALLS.join(&plugin.name).join(&version),
         };
-        let download_path = dirs::DOWNLOADS.join(&plugin.name).join(&version);
-        let cache_path = dirs::CACHE.join(&plugin.name).join(&version);
+        let download_path = match &install_type {
+            InstallType::Path(p) => p.clone(),
+            _ => dirs::DOWNLOADS.join(&plugin.name).join(&version),
+        };
+        let cache_path = match &install_type {
+            InstallType::Path(p) => dirs::CACHE.join(&plugin.name).join(hash_to_str(&p)),
+            _ => dirs::CACHE.join(&plugin.name).join(&version),
+        };
         Self {
             script_man: build_script_man(
                 install_type.clone(),

--- a/src/toolset/tool_source.rs
+++ b/src/toolset/tool_source.rs
@@ -1,6 +1,7 @@
-use crate::file::display_path;
 use std::fmt::{Display, Formatter};
 use std::path::PathBuf;
+
+use crate::file::display_path;
 
 /// where a tool version came from (e.g.: .tool-versions)
 #[derive(Debug, Clone)]
@@ -21,5 +22,26 @@ impl Display for ToolSource {
             ToolSource::Argument => write!(f, "--runtime"),
             ToolSource::Environment(k, v) => write!(f, "{k}={v}"),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use pretty_assertions::assert_str_eq;
+
+    use super::*;
+
+    #[test]
+    fn test_tool_source_display() {
+        let path = PathBuf::from("/home/user/.tool-versions");
+
+        let ts = ToolSource::ToolVersions(path);
+        assert_str_eq!(ts.to_string(), "/home/user/.tool-versions");
+
+        let ts = ToolSource::Argument;
+        assert_str_eq!(ts.to_string(), "--runtime");
+
+        let ts = ToolSource::Environment("RTX_NODEJS_VERSION".to_string(), "20".to_string());
+        assert_str_eq!(ts.to_string(), "RTX_NODEJS_VERSION=20");
     }
 }

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -37,61 +37,81 @@ impl ToolVersion {
     }
 
     pub fn resolve(&mut self, settings: &Settings, plugin: Arc<Plugin>) -> Result<()> {
-        if self.rtv.is_some() {
-            return Ok(());
+        if self.rtv.is_none() {
+            self.rtv = match &self.r#type {
+                ToolVersionType::Version(v) => self.resolve_version(settings, plugin, v)?,
+                ToolVersionType::Prefix(v) => self.resolve_prefix(settings, plugin, v)?,
+                ToolVersionType::Ref(r) => self.resolve_ref(plugin, r)?,
+                ToolVersionType::Path(path) => self.resolve_path(plugin, path)?,
+                ToolVersionType::System => None,
+            };
         }
-        match self.r#type.clone() {
-            ToolVersionType::Version(v) => self.resolve_version(settings, plugin, &v),
-            ToolVersionType::Prefix(v) => self.resolve_prefix(settings, plugin, &v),
-            ToolVersionType::Ref(r) => {
-                self.rtv = Some(RuntimeVersion::new(plugin, InstallType::Ref(r)));
-                Ok(())
-            }
-            ToolVersionType::Path(path) => {
-                let path = fs::canonicalize(path)?;
-                self.rtv = Some(RuntimeVersion::new(plugin, InstallType::Path(path)));
-                Ok(())
-            }
-            ToolVersionType::System => Ok(()),
-        }
+        Ok(())
     }
 
-    fn resolve_version(&mut self, settings: &Settings, plugin: Arc<Plugin>, v: &str) -> Result<()> {
+    fn resolve_version(
+        &self,
+        settings: &Settings,
+        plugin: Arc<Plugin>,
+        v: &str,
+    ) -> Result<Option<RuntimeVersion>> {
         let v = resolve_alias(settings, plugin.clone(), v)?;
+        match v.split_once(':') {
+            Some(("ref", r)) => {
+                return self.resolve_ref(plugin, r);
+            }
+            Some(("path", p)) => {
+                return self.resolve_path(plugin, p);
+            }
+            Some(("prefix", p)) => {
+                return self.resolve_prefix(settings, plugin, p);
+            }
+            Some(("system", _)) => {
+                return Ok(None);
+            }
+            _ => (),
+        }
 
         if dirs::INSTALLS.join(&plugin.name).join(&v).exists() {
             // if the version is already installed, no need to fetch all of the remote versions
-            self.rtv = Some(RuntimeVersion::new(plugin, InstallType::Version(v)));
-            return Ok(());
+            let rtv = RuntimeVersion::new(plugin, InstallType::Version(v));
+            return Ok(Some(rtv));
         }
 
         let matches = plugin.list_versions_matching(settings, &v)?;
         if matches.contains(&v) {
-            self.rtv = Some(RuntimeVersion::new(plugin, InstallType::Version(v)));
+            let rtv = RuntimeVersion::new(plugin, InstallType::Version(v));
+            Ok(Some(rtv))
         } else {
-            self.resolve_prefix(settings, plugin, &v)?;
+            self.resolve_prefix(settings, plugin, &v)
         }
-
-        Ok(())
     }
 
     fn resolve_prefix(
-        &mut self,
+        &self,
         settings: &Settings,
         plugin: Arc<Plugin>,
         prefix: &str,
-    ) -> Result<()> {
+    ) -> Result<Option<RuntimeVersion>> {
         let matches = plugin.list_versions_matching(settings, prefix)?;
         let v = match matches.last() {
             Some(v) => v,
             None => prefix,
             // None => Err(VersionNotFound(plugin.name.clone(), prefix.to_string()))?,
         };
-        self.rtv = Some(RuntimeVersion::new(
-            plugin,
-            InstallType::Version(v.to_string()),
-        ));
-        Ok(())
+        let rtv = RuntimeVersion::new(plugin, InstallType::Version(v.to_string()));
+        Ok(Some(rtv))
+    }
+
+    fn resolve_ref(&self, plugin: Arc<Plugin>, r: &str) -> Result<Option<RuntimeVersion>> {
+        let rtv = RuntimeVersion::new(plugin, InstallType::Ref(r.to_string()));
+        Ok(Some(rtv))
+    }
+
+    fn resolve_path(&self, plugin: Arc<Plugin>, path: &str) -> Result<Option<RuntimeVersion>> {
+        let path = fs::canonicalize(path)?;
+        let rtv = RuntimeVersion::new(plugin, InstallType::Path(path));
+        Ok(Some(rtv))
     }
 
     pub fn is_missing(&self) -> bool {
@@ -104,14 +124,10 @@ impl ToolVersion {
     pub fn install(&mut self, config: &Config, pr: ProgressReport) -> Result<()> {
         match self.r#type {
             ToolVersionType::Version(_) | ToolVersionType::Prefix(_) | ToolVersionType::Ref(_) => {
-                self.rtv.as_ref().unwrap().install(config, pr)?;
+                self.rtv.as_ref().unwrap().install(config, pr)
             }
-            _ => (),
+            _ => Ok(()),
         }
-        if matches!(self.r#type, ToolVersionType::System) {
-            return Ok(());
-        }
-        Ok(())
     }
 }
 


### PR DESCRIPTION
this also allows aliasing `prefix:` and `system`. (no idea why one might want to alias system, but I figure we can allow it)

I noticed this thread and realized people need to alias these as well:
* https://github.com/asdf-vm/asdf-elixir/pull/63