### PR TITLE
bug: fix order of env and path when using multiple versions

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -3,3 +3,4 @@ shellcheck 0.9.0
 shfmt 3.6.0 # test comment
 #nodejs 18.13.0
 jq latest
+tiny 2 1 3

--- a/e2e/cd/test_bash
+++ b/e2e/cd/test_bash
@@ -20,12 +20,12 @@ assert_path() {
 }
 
 test "$(node -v)" = "v18.0.0"
-assert_path "~/.rtx/installs/nodejs/18.0.0/bin:~/.rtx/installs/jq/1.6/bin:~/.rtx/installs/shfmt/3.6.0/bin:~/.rtx/installs/shellcheck/0.9.0/bin"
+assert_path "~/.rtx/installs/nodejs/18.0.0/bin:~/.rtx/installs/shellcheck/0.9.0/bin:~/.rtx/installs/shfmt/3.6.0/bin:~/.rtx/installs/jq/1.6/bin"
 
 cd 16 && _rtx_hook
 test "$(node -v)" = "v16.0.0"
-assert_path "~/.rtx/installs/nodejs/16.0.0/bin:~/.rtx/installs/jq/1.6/bin:~/.rtx/installs/shfmt/3.6.0/bin:~/.rtx/installs/shellcheck/0.9.0/bin"
+assert_path "~/.rtx/installs/nodejs/16.0.0/bin:~/.rtx/installs/shellcheck/0.9.0/bin:~/.rtx/installs/shfmt/3.6.0/bin:~/.rtx/installs/jq/1.6/bin"
 
 cd .. && _rtx_hook
 test "$(node -v)" = "v18.0.0"
-assert_path "~/.rtx/installs/nodejs/18.0.0/bin:~/.rtx/installs/jq/1.6/bin:~/.rtx/installs/shfmt/3.6.0/bin:~/.rtx/installs/shellcheck/0.9.0/bin"
+assert_path "~/.rtx/installs/nodejs/18.0.0/bin:~/.rtx/installs/shellcheck/0.9.0/bin:~/.rtx/installs/shfmt/3.6.0/bin:~/.rtx/installs/jq/1.6/bin"

--- a/src/cli/direnv/snapshots/rtx__cli__direnv__envrc__tests__direnv_envrc.snap
+++ b/src/cli/direnv/snapshots/rtx__cli__direnv__envrc__tests__direnv_envrc.snap
@@ -7,8 +7,8 @@ watch_file ~/cwd/.test-tool-versions
 watch_file ~/cwd/.node-version
 watch_file ~/.test-tool-versions
 export JDXCODE_TINY=2.1.0
-PATH_add ~/data/installs/jq/1.6/bin
 PATH_add ~/data/installs/tiny/2.1.0/bin
-PATH_add ~/data/installs/shellcheck/0.9.0/bin
+PATH_add ~/data/installs/jq/1.6/bin
 PATH_add ~/data/installs/shfmt/3.5.1/bin
+PATH_add ~/data/installs/shellcheck/0.9.0/bin
 

--- a/src/cli/env.rs
+++ b/src/cli/env.rs
@@ -110,8 +110,8 @@ mod tests {
 
     #[test]
     fn test_env_tiny() {
-        let stdout = assert_cli!("env", "tiny@1", "-s", "bash");
-        assert_str_eq!(grep(stdout, "JDXCODE"), "export JDXCODE_TINY=1.0.1");
+        let stdout = assert_cli!("env", "tiny@2", "tiny@1", "tiny@3", "-s", "bash");
+        assert_str_eq!(grep(stdout, "JDXCODE"), "export JDXCODE_TINY=2.1.0");
     }
 
     #[test]

--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -168,6 +168,13 @@ mod tests {
         });
     }
     #[test]
+    fn test_local_multiple_versions() {
+        run_test(|| {
+            assert_cli_snapshot!("local", "tiny@2", "tiny@1", "tiny@3");
+            assert_cli_snapshot!("bin-paths");
+        });
+    }
+    #[test]
     fn test_local_output_current_version() {
         run_test(|| {
             assert_cli!("local", "tiny", "2");

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -243,6 +243,7 @@ pub mod tests {
             let args = &vec!["rtx".into(), $($args.into()),+];
             let output = $crate::cli::tests::cli_run(args).unwrap().stdout.content;
             let output = console::strip_ansi_codes(&output).to_string();
+            let output = output.replace($crate::dirs::HOME.to_string_lossy().as_ref(), "~");
             assert_snapshot!(output);
         }};
     }

--- a/src/cli/snapshots/rtx__cli__local__tests__local_multiple_versions-2.snap
+++ b/src/cli/snapshots/rtx__cli__local__tests__local_multiple_versions-2.snap
@@ -1,0 +1,11 @@
+---
+source: src/cli/local.rs
+expression: output
+---
+~/data/installs/shellcheck/0.9.0/bin
+~/data/installs/shfmt/3.5.1/bin
+~/data/installs/tiny/2.1.0/bin
+~/data/installs/tiny/1.0.1/bin
+~/data/installs/tiny/3.1.0/bin
+~/data/installs/jq/1.6/bin
+

--- a/src/cli/snapshots/rtx__cli__local__tests__local_multiple_versions.snap
+++ b/src/cli/snapshots/rtx__cli__local__tests__local_multiple_versions.snap
@@ -1,0 +1,11 @@
+---
+source: src/cli/local.rs
+expression: output
+---
+#python 3.11.1 3.10.9 # foo
+shellcheck 0.9.0
+shfmt 3.5.1 # test comment
+#nodejs 18.13.0
+nodejs system
+tiny 2 1 3
+


### PR DESCRIPTION
this also reversed the order of tool-versions so now it will export PATH that is equivalent to the tool-versions file.

e.g.: this tool-versions:

```
nodejs 18
python 3.11
```

will export:

```
PATH="~/.rtx/installs/node/18/bin:~/.rtx/installs/python/3.11/bin"
```

this shouldn't matter in nearly any case but it should fit more what people expect