### PR TITLE
feat: added `RTX_DISABLE_DEFAULT_SHORTHANDS` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,9 +384,10 @@ always_keep_download = false        # deleted after install by default
 # (note: this isn't currently implemented but there are plans to add it: https://github.com/jdxcode/rtx/issues/128)
 plugin_autoupdate_last_check_duration = 10080 # (one week) set to 0 to disable updates
 
-jobs = 4 # number of plugins or runtimes to install in parallel. The default is `4`.
-verbose = false # see explanation under `RTX_VERBOSE`
-asdf_compat = false # see explanation under `RTX_ASDF_COMPAT`
+verbose = false     # set to true to see full installation output, see `RTX_VERBOSE`
+asdf_compat = false # set to true to ensure .tool-versions will be compatible with asdf, see `RTX_ASDF_COMPAT`
+jobs = 4            # number of plugins or runtimes to install in parallel. The default is `4`.
+disable_default_shorthands = false # disable the default shorthands, see `RTX_DISABLE_DEFAULT_SHORTHANDS`
 
 [alias.nodejs]
 my_custom_node = '18'  # makes `rtx install nodejs@my_custom_node` install node-18.x
@@ -449,10 +450,6 @@ Output logs to a file.
 Same as `RTX_LOG_LEVEL` but for the log file output level. This is useful if you want
 to store the logs but not have them litter your display.
 
-#### `RTX_JOBS=1`
-
-Set the number plugins or runtimes to install in parallel. The default is `4`.
-
 #### `RTX_VERBOSE=1`
 
 This shows the installation output during `rtx install` and `rtx plugin install`.
@@ -462,6 +459,15 @@ This should likely be merged so it behaves the same as `RTX_DEBUG=1` and we don'
 #### `RTX_ASDF_COMPAT=1`
 
 Only output `.tool-versions` files in `rtx local|global` which will be usable by asdf.
+
+#### `RTX_JOBS=1`
+
+Set the number plugins or runtimes to install in parallel. The default is `4`.
+
+#### `RTX_DISABLE_DEFAULT_SHORTHANDS=1`
+
+Disables the shorthand aliases for installing plugins. You will have to specify full urls when
+installing plugins, e.g.: `rtx plugin install nodejs https://github.com/asdf-vm/asdf-nodejs.git`
 
 Currently this disables the following:
 

--- a/src/cli/plugins/ls_remote.rs
+++ b/src/cli/plugins/ls_remote.rs
@@ -30,6 +30,10 @@ impl Command for PluginsLsRemote {
             .map(|p| p.name.clone())
             .collect::<HashSet<_>>();
 
+        if config.settings.disable_default_shorthands {
+            warn!("default shorthands are disabled");
+            return Ok(());
+        }
         for (plugin, repo) in SHORTHAND_MAP.iter().sorted().collect_vec() {
             let installed = if installed_plugins.contains(*plugin) {
                 "*"

--- a/src/cli/render_help.rs
+++ b/src/cli/render_help.rs
@@ -403,9 +403,10 @@ always_keep_download = false        # deleted after install by default
 # (note: this isn't currently implemented but there are plans to add it: https://github.com/jdxcode/rtx/issues/128)
 plugin_autoupdate_last_check_duration = 10080 # (one week) set to 0 to disable updates
 
-jobs = 4 # number of plugins or runtimes to install in parallel. The default is `4`.
-verbose = false # see explanation under `RTX_VERBOSE`
-asdf_compat = false # see explanation under `RTX_ASDF_COMPAT`
+verbose = false     # set to true to see full installation output, see `RTX_VERBOSE`
+asdf_compat = false # set to true to ensure .tool-versions will be compatible with asdf, see `RTX_ASDF_COMPAT`
+jobs = 4            # number of plugins or runtimes to install in parallel. The default is `4`.
+disable_default_shorthands = false # disable the default shorthands, see `RTX_DISABLE_DEFAULT_SHORTHANDS`
 
 [alias.nodejs]
 my_custom_node = '18'  # makes `rtx install nodejs@my_custom_node` install node-18.x
@@ -468,10 +469,6 @@ Output logs to a file.
 Same as `RTX_LOG_LEVEL` but for the log file output level. This is useful if you want
 to store the logs but not have them litter your display.
 
-#### `RTX_JOBS=1`
-
-Set the number plugins or runtimes to install in parallel. The default is `4`.
-
 #### `RTX_VERBOSE=1`
 
 This shows the installation output during `rtx install` and `rtx plugin install`.
@@ -481,6 +478,15 @@ This should likely be merged so it behaves the same as `RTX_DEBUG=1` and we don'
 #### `RTX_ASDF_COMPAT=1`
 
 Only output `.tool-versions` files in `rtx local|global` which will be usable by asdf.
+
+#### `RTX_JOBS=1`
+
+Set the number plugins or runtimes to install in parallel. The default is `4`.
+
+#### `RTX_DISABLE_DEFAULT_SHORTHANDS=1`
+
+Disables the shorthand aliases for installing plugins. You will have to specify full urls when
+installing plugins, e.g.: `rtx plugin install nodejs https://github.com/asdf-vm/asdf-nodejs.git`
 
 Currently this disables the following:
 

--- a/src/cli/settings/snapshots/rtx__cli__settings__ls__tests__settings_ls.snap
+++ b/src/cli/settings/snapshots/rtx__cli__settings__ls__tests__settings_ls.snap
@@ -9,5 +9,6 @@ plugin_autoupdate_last_check_duration = 20
 verbose = true
 asdf_compat = false
 jobs = 2
+disable_default_shorthands = false
 log_level = INFO
 

--- a/src/cli/settings/snapshots/rtx__cli__settings__set__tests__settings_set.snap
+++ b/src/cli/settings/snapshots/rtx__cli__settings__set__tests__settings_set.snap
@@ -9,5 +9,6 @@ plugin_autoupdate_last_check_duration = 1
 verbose = true
 asdf_compat = false
 jobs = 2
+disable_default_shorthands = false
 log_level = INFO
 

--- a/src/cli/settings/unset.rs
+++ b/src/cli/settings/unset.rs
@@ -55,6 +55,7 @@ mod tests {
         verbose = true
         asdf_compat = false
         jobs = 2
+        disable_default_shorthands = false
         log_level = INFO
         "###);
 

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -6,7 +6,9 @@ use log::LevelFilter;
 
 use crate::config::AliasMap;
 use crate::env;
-use crate::env::{RTX_ASDF_COMPAT, RTX_JOBS, RTX_LOG_LEVEL, RTX_VERBOSE};
+use crate::env::{
+    RTX_ASDF_COMPAT, RTX_DISABLE_DEFAULT_SHORTHANDS, RTX_JOBS, RTX_LOG_LEVEL, RTX_VERBOSE,
+};
 use crate::plugins::PluginName;
 
 #[derive(Debug, Clone)]
@@ -19,6 +21,7 @@ pub struct Settings {
     pub verbose: bool,
     pub asdf_compat: bool,
     pub jobs: usize,
+    pub disable_default_shorthands: bool,
     pub log_level: LevelFilter,
 }
 
@@ -33,6 +36,7 @@ impl Default for Settings {
             verbose: *RTX_VERBOSE || !console::user_attended_stderr(),
             asdf_compat: *RTX_ASDF_COMPAT,
             jobs: *RTX_JOBS,
+            disable_default_shorthands: *RTX_DISABLE_DEFAULT_SHORTHANDS,
             log_level: *RTX_LOG_LEVEL,
         }
     }
@@ -60,6 +64,10 @@ impl Settings {
         map.insert("verbose".into(), self.verbose.to_string());
         map.insert("asdf_compat".into(), self.asdf_compat.to_string());
         map.insert("jobs".into(), self.jobs.to_string());
+        map.insert(
+            "disable_default_shorthands".into(),
+            self.disable_default_shorthands.to_string(),
+        );
         map.insert("log_level".into(), self.log_level.to_string());
         map
     }
@@ -75,6 +83,7 @@ pub struct SettingsBuilder {
     pub verbose: Option<bool>,
     pub asdf_compat: Option<bool>,
     pub jobs: Option<usize>,
+    pub disable_default_shorthands: Option<bool>,
     pub log_level: Option<LevelFilter>,
 }
 
@@ -107,6 +116,9 @@ impl SettingsBuilder {
         }
         if other.jobs.is_some() {
             self.jobs = other.jobs;
+        }
+        if other.disable_default_shorthands.is_some() {
+            self.disable_default_shorthands = other.disable_default_shorthands;
         }
         if other.log_level.is_some() {
             self.log_level = other.log_level;
@@ -145,6 +157,9 @@ impl SettingsBuilder {
         settings.verbose = self.verbose.unwrap_or(settings.verbose);
         settings.asdf_compat = self.asdf_compat.unwrap_or(settings.asdf_compat);
         settings.jobs = self.jobs.unwrap_or(settings.jobs);
+        settings.disable_default_shorthands = self
+            .disable_default_shorthands
+            .unwrap_or(settings.disable_default_shorthands);
         settings.aliases = self.aliases.clone().unwrap_or(settings.aliases);
 
         settings

--- a/src/env.rs
+++ b/src/env.rs
@@ -118,6 +118,7 @@ lazy_static! {
     pub static ref RTX_HIDE_OUTDATED_BUILD: bool = var_is_true("RTX_HIDE_OUTDATED_BUILD");
     pub static ref RTX_PREFER_STALE: bool = prefer_stale(&ARGS);
     pub static ref RTX_ASDF_COMPAT: bool = var_is_true("RTX_ASDF_COMPAT");
+    pub static ref RTX_DISABLE_DEFAULT_SHORTHANDS: bool = var_is_true("RTX_DISABLE_DEFAULT_SHORTHANDS");
 }
 
 fn get_env_diff() -> EnvDiff {

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -114,7 +114,7 @@ impl Plugin {
         ));
         pr.enable_steady_tick();
         let repository = repository
-            .or_else(|| shorthand_to_repository(&self.name))
+            .or_else(|| shorthand_to_repository(settings, &self.name))
             .ok_or_else(|| eyre!("No repository found for plugin {}", self.name))?;
         debug!("install {} {:?}", self.name, repository);
         if self.is_installed() {

--- a/src/shorthand.rs
+++ b/src/shorthand.rs
@@ -1,9 +1,14 @@
+use crate::config::Settings;
 use crate::shorthand_list::SHORTHAND_LIST;
 use once_cell::sync::Lazy;
 use std::collections::HashMap;
 
-pub fn shorthand_to_repository(name: &str) -> Option<&'static str> {
-    SHORTHAND_MAP.get(name).copied()
+pub fn shorthand_to_repository(settings: &Settings, name: &str) -> Option<&'static str> {
+    if !settings.disable_default_shorthands {
+        SHORTHAND_MAP.get(name).copied()
+    } else {
+        None
+    }
 }
 
 pub static SHORTHAND_MAP: Lazy<HashMap<&'static str, &'static str>> =


### PR DESCRIPTION
See #163

```
❯ RTX_DISABLE_DEFAULT_SHORTHANDS=1 rtx i nodejs@18
[ERROR] No repository found for plugin nodejs
[ERROR] Run with RTX_DEBUG=1 for more information.
[ERROR] rtx 1.14.3-DEBUG macos-arm64 (built 2023-02-22)
❯ RTX_DISABLE_DEFAULT_SHORTHANDS=0 rtx i nodejs@18
rtx nodejs ✓ https://github.com/asdf-vm/asdf-nodejs.git@c9e5df4                                     2s
rtx nodejs@18.14.2 ✓                                                                                7s
```