### PR TITLE
fix: ignore env varibales from exported bash functions

### DIFF
--- a/src/env_diff.rs
+++ b/src/env_diff.rs
@@ -97,6 +97,14 @@ impl EnvDiff {
                 // it causes ruby to attempt to call asdf to reshim the binaries
                 // which we don't need or want to happen
                 || k == "RUBYLIB"
+                // following two ignores are for exported bash functions and exported bash
+                // functions which are multline, they appear in the environment as e.g.:
+                // BASH_FUNC_exported-bash-function%%=() { echo "this is an"
+                //  echo "exported bash function"
+                //  echo "with multiple lines"
+                // }
+                || k.starts_with("BASH_FUNC_")
+                || k.starts_with(' ')
             {
                 continue;
             }


### PR DESCRIPTION
THis PR adds ignoring of environment variables that are present as a result of exported bash functions and exported bash functions consisting fo multiple lines. e.g.:

```
$ env
...
BASH_FUNC_docker-update-images%%=() {  local _images;
 _images=$(docker images --digests | grep -v REPOSITORY | awk '{ if ($1 != "<none>" && $2 != "<none>" && $3 != "<none>") { printf("%s:%s\n", $1, $2) } }' | sort -u);
 [[ -n "${DOCKER_IMAGE_FILTER}" ]] && _images=$(echo "${_images}" | grep -E -v "${DOCKER_IMAGE_FILTER}");
 for image in ${_images};
 do
 docker pull "$image";
 done;
 unset _images
}
...
```

Originaly rtx would try to export each of these lines which resulted in bash errors. e.g.:

```
-bash: export: ` _images=$(docker images --digests | grep -v REPOSITORY | awk '{ if ($1 != "<none>" && $2 != "<none>" && $3 != "<none>") { printf("%s:%s\n", $1, $2) } }' | sort -u);': not a valid identifier
```