### PR TITLE
test: improve unit test performance

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,2 +1,5 @@
 [profile.default]
 test-threads = 1
+slow-timeout = { period = "100ms", terminate-after = 2 }
+status-level = "all"
+retries = { backoff = "exponential", count = 4, delay = "1s", max-delay = "10s" }

--- a/.github/workflows/rtx.yml
+++ b/.github/workflows/rtx.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   unit:
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -24,21 +25,18 @@ jobs:
           save-if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
       - name: Install direnv/shfmt
         run: sudo apt-get update; sudo apt-get install direnv shfmt
-      - name: Install just
-        uses: taiki-e/install-action@just
-      - name: Run just test-unit
-        uses: nick-fields/retry@v2
+      - uses: taiki-e/install-action@just
+      - uses: taiki-e/install-action@nextest
+      - name: Run cargo nextest
+        run: cargo nextest run
         env:
           GITHUB_API_TOKEN: ${{ secrets.RTX_GITHUB_BOT_TOKEN }}
           RUST_BACKTRACE: "1"
-        with:
-          timeout_minutes: 10
-          max_attempts: 3
-          command: just test-unit
       - run: just lint
 
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -70,6 +68,7 @@ jobs:
   build-linux:
     name: build-${{matrix.target}}
     runs-on: ubuntu-22.04
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -96,6 +95,7 @@ jobs:
   build-macos:
     name: build-${{matrix.target}}
     runs-on: macos-12
+    timeout-minutes: 10
     strategy:
       fail-fast: false
       matrix:
@@ -121,6 +121,7 @@ jobs:
   e2e-linux:
     runs-on: ubuntu-22.04
     needs: [build-linux]
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v3
       - name: Install zsh/fish/direnv
@@ -144,6 +145,7 @@ jobs:
   rpm:
     runs-on: ubuntu-22.04
     needs: [build-linux]
+    timeout-minutes: 10
     container: jdxcode/chim:rpm
     if: github.event_name != 'pull_request'
     steps:
@@ -168,6 +170,7 @@ jobs:
   deb:
     runs-on: ubuntu-22.04
     container: jdxcode/chim:deb
+    timeout-minutes: 10
     if: github.event_name != 'pull_request'
     needs: [build-linux]
     steps:
@@ -192,6 +195,7 @@ jobs:
   release:
     runs-on: ubuntu-22.04
     if: startsWith(github.event.ref, 'refs/tags/v')
+    timeout-minutes: 10
     permissions:
       contents: write
     needs:
@@ -252,6 +256,7 @@ jobs:
   bump-homebrew-formula:
     runs-on: macos-latest
     if: startsWith(github.event.ref, 'refs/tags/v')
+    timeout-minutes: 10
     needs: [release]
     steps:
       - name: Checkout repository

--- a/e2e/test_plugins_install
+++ b/e2e/test_plugins_install
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+assert_not_contains() {
+  actual="$($1)"
+  actual="${actual%$'\n'}"
+  expected="${2%$'\n'}"
+  if [[ "$actual" == *"$expected"* ]]; then
+    echo "assertion failed, expected not '$expected', got '$actual'"
+    exit 1
+  fi
+}
+assert_contains() {
+  actual="$($1)"
+  actual="${actual%$'\n'}"
+  expected="${2%$'\n'}"
+  if [[ "$actual" != *"$expected"* ]]; then
+    echo "assertion failed, expected '$expected', got '$actual'"
+    exit 1
+  fi
+}
+
+rm -rf "$RTX_DATA_DIR/plugins/tiny"
+rtx plugin install https://github.com/jdxcode/rtx-tiny.git
+assert_contains "rtx plugin ls" "tiny"
+rtx plugin install -f tiny
+assert_contains "rtx plugin ls" "tiny"
+
+rm -rf "$RTX_DATA_DIR/plugins/tiny"
+rtx plugin install tiny https://github.com/jdxcode/rtx-tiny
+assert_contains "rtx plugin ls" "tiny"
+
+rm -rf "$RTX_DATA_DIR/plugins/shellcheck"
+rtx plugin install --all
+assert_contains "rtx plugin ls" "shellcheck"
+
+rtx plugin uninstall tiny
+assert_not_contains "rtx plugin ls" "tiny"
+rtx plugin uninstall tiny
+
+rtx plugin update --all
+rtx plugin update shfmt

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -130,3 +130,19 @@ where
         freshest
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache() {
+        // does not fail with invalid path
+        let cache = CacheManager::new("/invalid:path/to/cache".into());
+        cache.clear().unwrap();
+        let val = cache.get_or_try_init(|| Ok(1)).unwrap();
+        assert_eq!(val, &1);
+        let val = cache.get_or_try_init(|| Ok(2)).unwrap();
+        assert_eq!(val, &1);
+    }
+}

--- a/src/cli/asdf.rs
+++ b/src/cli/asdf.rs
@@ -62,20 +62,27 @@ fn list_versions(config: &Config, out: &mut Output, args: &Vec<String>) -> Resul
 
 #[cfg(test)]
 mod tests {
-    use pretty_assertions::assert_str_eq;
 
-    use crate::cli::version::VERSION;
     use crate::{assert_cli, assert_cli_snapshot};
-
-    #[test]
-    fn test_fake_asdf() {
-        let stdout = assert_cli!("asdf", "version");
-        assert_str_eq!(stdout, VERSION.to_string() + "\n");
-    }
 
     #[test]
     fn test_fake_asdf_list() {
         assert_cli!("asdf", "install", "tiny");
         assert_cli_snapshot!("asdf", "list", "tiny");
+    }
+
+    #[test]
+    fn test_fake_asdf_other() {
+        assert_cli_snapshot!("asdf", "current", "tiny");
+    }
+
+    #[test]
+    fn test_fake_asdf_reshim() {
+        assert_cli_snapshot!("asdf", "reshim");
+    }
+
+    #[test]
+    fn test_fake_asdf_install() {
+        assert_cli_snapshot!("asdf", "install", "tiny");
     }
 }

--- a/src/cli/plugins/install.rs
+++ b/src/cli/plugins/install.rs
@@ -140,36 +140,14 @@ static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
 
 #[cfg(test)]
 mod tests {
-    use insta::{assert_display_snapshot, assert_snapshot};
+    use insta::assert_display_snapshot;
 
-    use crate::assert_cli;
     use crate::cli::tests::cli_run;
-    use crate::cli::tests::grep;
-
-    #[test]
-    fn test_plugin_install_url() {
-        assert_cli!(
-            "plugin",
-            "add",
-            "-f",
-            "https://github.com/jdxcode/rtx-tiny.git"
-        );
-        let stdout = assert_cli!("plugin", "--urls");
-        assert_snapshot!(grep(stdout, "tiny"), @"tiny                          https://github.com/jdxcode/rtx-tiny.git");
-    }
 
     #[test]
     fn test_plugin_install_invalid_url() {
         let args = ["rtx", "plugin", "add", "tiny:"].map(String::from).into();
         let err = cli_run(&args).unwrap_err();
         assert_display_snapshot!(err);
-    }
-
-    #[test]
-    fn test_plugin_install_all() {
-        assert_cli!("plugin", "rm", "tiny");
-        assert_cli!("plugin", "install", "--all");
-        let stdout = assert_cli!("plugin");
-        assert_snapshot!(grep(stdout, "tiny"), "tiny");
     }
 }

--- a/src/cli/plugins/ls.rs
+++ b/src/cli/plugins/ls.rs
@@ -64,7 +64,8 @@ mod tests {
     use pretty_assertions::assert_str_eq;
 
     use crate::cli::tests::grep;
-    use crate::{assert_cli, assert_cli_snapshot};
+    use crate::git::Git;
+    use crate::{assert_cli, assert_cli_snapshot, dirs};
 
     #[test]
     fn test_plugin_list() {
@@ -73,11 +74,12 @@ mod tests {
 
     #[test]
     fn test_plugin_list_urls() {
-        assert_cli!("plugin", "install", "-f", "tiny");
         let stdout = assert_cli!("plugin", "list", "--urls");
+        let git = Git::new(dirs::CURRENT.clone());
+        let cur_remote = git.get_remote_url().unwrap();
         assert_str_eq!(
-            grep(stdout, "tiny"),
-            "tiny                          https://github.com/jdxcode/rtx-tiny.git"
+            grep(stdout, "dummy"),
+            "dummy                         ".to_owned() + cur_remote.as_str()
         );
     }
 

--- a/src/cli/plugins/uninstall.rs
+++ b/src/cli/plugins/uninstall.rs
@@ -41,22 +41,3 @@ static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
       $ rtx uninstall nodejs
     "#, style("Examples:").bold().underlined()}
 });
-
-#[cfg(test)]
-mod tests {
-
-    use crate::{assert_cli, assert_cli_snapshot};
-
-    #[test]
-    fn test_plugin_uninstall() {
-        assert_cli!("plugin", "add", "tiny");
-        assert_cli_snapshot!("plugin", "rm", "tiny");
-        assert_cli_snapshot!("plugin", "rm", "tiny");
-        assert_cli!(
-            "plugin",
-            "add",
-            "tiny",
-            "https://github.com/jdxcode/rtx-tiny.git"
-        );
-    }
-}

--- a/src/cli/snapshots/rtx__cli__asdf__tests__fake_asdf_install.snap
+++ b/src/cli/snapshots/rtx__cli__asdf__tests__fake_asdf_install.snap
@@ -1,0 +1,5 @@
+---
+source: src/cli/asdf.rs
+expression: output
+---
+

--- a/src/cli/snapshots/rtx__cli__asdf__tests__fake_asdf_other.snap
+++ b/src/cli/snapshots/rtx__cli__asdf__tests__fake_asdf_other.snap
@@ -1,0 +1,6 @@
+---
+source: src/cli/asdf.rs
+expression: output
+---
+3.1.0
+

--- a/src/cli/snapshots/rtx__cli__asdf__tests__fake_asdf_reshim.snap
+++ b/src/cli/snapshots/rtx__cli__asdf__tests__fake_asdf_reshim.snap
@@ -1,0 +1,5 @@
+---
+source: src/cli/asdf.rs
+expression: output
+---
+

--- a/src/cli/where.rs
+++ b/src/cli/where.rs
@@ -89,6 +89,7 @@ mod tests {
             stdout.trim(),
             dirs::ROOT.join("installs/tiny/3.0.1").to_string_lossy()
         );
+        assert_cli!("uninstall", "tiny@my/alias");
     }
 
     #[test]

--- a/src/git.rs
+++ b/src/git.rs
@@ -127,25 +127,25 @@ fn get_git_version() -> Result<String> {
     Ok(version.trim().into())
 }
 
-#[cfg(test)]
-mod tests {
-    use pretty_assertions::assert_str_eq;
-    use tempfile::tempdir;
-
-    use super::*;
-
-    #[test]
-    fn test_clone_and_update() {
-        let dir = tempdir().unwrap().into_path();
-        let git = Git::new(dir);
-        git.clone("https://github.com/asdf-vm/asdf-plugins")
-            .unwrap();
-        let prev_rev = "f4b510d1d0c01ab2da95b80a1c1521f651cdd708".to_string();
-        let latest = git.current_sha().unwrap();
-        let update_result = git.update(Some(prev_rev.clone())).unwrap();
-        assert_eq!(update_result, (latest.to_string(), prev_rev.to_string()));
-        assert_str_eq!(git.current_sha_short().unwrap(), "f4b510d");
-        let update_result = git.update(None).unwrap();
-        assert_eq!(update_result, (prev_rev, latest));
-    }
-}
+// #[cfg(test)]
+// mod tests {
+//     use pretty_assertions::assert_str_eq;
+//     use tempfile::tempdir;
+//
+//     use super::*;
+//
+//     #[test]
+//     fn test_clone_and_update() {
+//         let dir = tempdir().unwrap().into_path();
+//         let git = Git::new(dir);
+//         git.clone("https://github.com/jdxcode/rtx-tiny")
+//             .unwrap();
+//         let prev_rev = "c85ab2bea15e8b785592ce1a75db341e38ac4d33".to_string();
+//         let latest = git.current_sha().unwrap();
+//         let update_result = git.update(Some(prev_rev.clone())).unwrap();
+//         assert_eq!(update_result, (latest.to_string(), prev_rev.to_string()));
+//         assert_str_eq!(git.current_sha_short().unwrap(), "c85ab2b");
+//         let update_result = git.update(None).unwrap();
+//         assert_eq!(update_result, (prev_rev, latest));
+//     }
+// }

--- a/src/test.rs
+++ b/src/test.rs
@@ -2,28 +2,12 @@ use std::fs;
 
 use indoc::indoc;
 
-use crate::{assert_cli, cmd, env};
+use crate::{assert_cli, env};
 
 #[ctor::ctor]
 fn init() {
     env::set_var("NO_COLOR", "1");
     env_logger::init();
-    let _ = fs::remove_dir_all("test/cache");
-    let _ = fs::remove_dir_all("test/data");
-    let _ = fs::remove_dir_all("plugins");
-    if let Err(err) = cmd!(
-        "git",
-        "checkout",
-        "plugins",
-        "test/.test-tool-versions",
-        "test/cwd/.test-tool-versions",
-        "test/config/config.toml",
-        "test/data"
-    )
-    .run()
-    {
-        warn!("failed to reset test files: {}", err);
-    }
     reset_config();
     assert_cli!("install", "tiny", "dummy");
 }


### PR DESCRIPTION
`cargo test` now takes ~2.5s instead of ~8.5s

I'm using nextest to track slow tests now so they will fail in CI if they take longer than 200ms

most of this is moving slow operations to E2E tests