### PR TITLE
bug: immediately call hook-env after activating

### DIFF
--- a/e2e/cd/test_bash
+++ b/e2e/cd/test_bash
@@ -6,7 +6,6 @@ orig_path="$PATH"
 
 # shellcheck disable=SC1090
 eval "$(rtx activate bash --status)"
-_rtx_hook
 
 assert_path() {
   local expected="${1//$HOME/\~}:"

--- a/e2e/cd/test_fish
+++ b/e2e/cd/test_fish
@@ -4,7 +4,7 @@
 #set -l fish_trace 1
 rtx install nodejs@18.0.0 nodejs@16.0.0; or exit
 
-rtx activate fish | source && __rtx_env_eval
+rtx activate fish | source
 #rtx i
 
 test (node -v) = "v18.0.0"; or exit

--- a/e2e/cd/test_zsh
+++ b/e2e/cd/test_zsh
@@ -4,7 +4,6 @@ set -euo pipefail
 rtx install nodejs@18.0.0 nodejs@16.0.0
 # shellcheck disable=SC1090
 eval "$(rtx activate zsh --status)"
-_rtx_hook
 
 #rtx install
 test "$(node -v)" = "v18.0.0"

--- a/justfile
+++ b/justfile
@@ -22,7 +22,7 @@ test *args: (test-unit args) test-e2e
 # update all test snapshot files
 test-update-snapshots:
     find . -name '*.snap' -delete
-    cargo insta test --accept
+    cargo insta test --accept --features clap_mangen
 
 # run the rust "unit" tests
 test-unit *args:

--- a/src/cli/plugins/snapshots/rtx__cli__plugins__install__tests__tiny.snap
+++ b/src/cli/plugins/snapshots/rtx__cli__plugins__install__tests__tiny.snap
@@ -1,5 +1,0 @@
----
-source: src/cli/plugins/install.rs
-expression: "\"tiny\""
----
-tiny

--- a/src/cli/plugins/snapshots/rtx__cli__plugins__uninstall__tests__plugin_uninstall-2.snap
+++ b/src/cli/plugins/snapshots/rtx__cli__plugins__uninstall__tests__plugin_uninstall-2.snap
@@ -1,5 +1,0 @@
----
-source: src/cli/plugins/uninstall.rs
-expression: output
----
-

--- a/src/cli/plugins/snapshots/rtx__cli__plugins__uninstall__tests__plugin_uninstall.snap
+++ b/src/cli/plugins/snapshots/rtx__cli__plugins__uninstall__tests__plugin_uninstall.snap
@@ -1,6 +1,0 @@
----
-source: src/cli/plugins/uninstall.rs
-expression: output
----
-uninstalling plugin: tiny
-

--- a/src/cli/snapshots/rtx__cli__activate__tests__activate_zsh.snap
+++ b/src/cli/snapshots/rtx__cli__activate__tests__activate_zsh.snap
@@ -17,3 +17,5 @@ if [[ -z "${chpwd_functions[(r)_rtx_hook]+1}" ]]; then
   chpwd_functions=( _rtx_hook ${chpwd_functions[@]} )
 fi
 
+_rtx_hook
+

--- a/src/cli/snapshots/rtx__cli__activate__tests__activate_zsh_legacy.snap
+++ b/src/cli/snapshots/rtx__cli__activate__tests__activate_zsh_legacy.snap
@@ -17,3 +17,5 @@ if [[ -z "${chpwd_functions[(r)_rtx_hook]+1}" ]]; then
   chpwd_functions=( _rtx_hook ${chpwd_functions[@]} )
 fi
 
+_rtx_hook
+

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -27,6 +27,8 @@ impl Shell for Bash {
             if ! [[ "${{PROMPT_COMMAND:-}}" =~ _rtx_hook ]]; then
               PROMPT_COMMAND="_rtx_hook${{PROMPT_COMMAND:+;$PROMPT_COMMAND}}"
             fi
+
+            _rtx_hook
             "#});
 
         out

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -45,6 +45,8 @@ impl Shell for Fish {
 
                 functions --erase __rtx_cd_hook;
             end;
+
+            __rtx_env_eval
         "#});
 
         out

--- a/src/shell/snapshots/rtx__shell__bash__tests__hook_init.snap
+++ b/src/shell/snapshots/rtx__shell__bash__tests__hook_init.snap
@@ -14,3 +14,5 @@ if ! [[ "${PROMPT_COMMAND:-}" =~ _rtx_hook ]]; then
   PROMPT_COMMAND="_rtx_hook${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
 fi
 
+_rtx_hook
+

--- a/src/shell/snapshots/rtx__shell__fish__tests__hook_init.snap
+++ b/src/shell/snapshots/rtx__shell__fish__tests__hook_init.snap
@@ -27,3 +27,5 @@ function __rtx_env_eval_2 --on-event fish_preexec --description 'Update rtx envi
     functions --erase __rtx_cd_hook;
 end;
 
+__rtx_env_eval
+

--- a/src/shell/snapshots/rtx__shell__zsh__tests__hook_init.snap
+++ b/src/shell/snapshots/rtx__shell__zsh__tests__hook_init.snap
@@ -17,3 +17,5 @@ if [[ -z "${chpwd_functions[(r)_rtx_hook]+1}" ]]; then
   chpwd_functions=( _rtx_hook ${chpwd_functions[@]} )
 fi
 
+_rtx_hook
+

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -34,6 +34,8 @@ impl Shell for Zsh {
             if [[ -z "${{chpwd_functions[(r)_rtx_hook]+1}}" ]]; then
               chpwd_functions=( _rtx_hook ${{chpwd_functions[@]}} )
             fi
+
+            _rtx_hook
             "#});
 
         out


### PR DESCRIPTION
Fixes #199

If you use activate in an rc file, this will make it so the binaries are available immediately, e.g.:

```
eval "$(rtx activate bash)"
jq # before this change this wouldn't work if it came from rtx
```