### PR TITLE
bug: fix multiline env vars

### DIFF
--- a/e2e/test_lua
+++ b/e2e/test_lua
@@ -1,0 +1,18 @@
+#!/usr/bin/env fish
+
+set -gx RTX_MISSING_RUNTIME_BEHAVIOR autoinstall
+
+rtx activate --status fish | source
+rtx shell lua@5.4.3
+
+set -l actual (__rtx_env_eval 2>&1 && lua -v 2>&1)
+set -l expected "rtx lua@5.4.3 shellcheck@0.9.0 shfmt@3.6.0 jq@1.6 nodejs@18.0.0 Lua 5.4.3  Copyright (C) 1994-2021 Lua.org, PUC-Rio"
+
+if test "$actual" = "$expected"
+    echo "OK"
+else
+    echo "FAIL"
+    echo "Expected: $expected"
+    echo "Actual: $actual"
+    exit 1
+end

--- a/src/cli/install.rs
+++ b/src/cli/install.rs
@@ -160,4 +160,10 @@ mod tests {
         );
         assert_cli!("global", "--unset", "dummy");
     }
+
+    #[test]
+    fn test_install_nothing() {
+        // this doesn't do anything since dummy isn't specified
+        assert_cli_snapshot!("install", "dummy");
+    }
 }

--- a/src/cli/snapshots/rtx__cli__install__tests__install_nothing.snap
+++ b/src/cli/snapshots/rtx__cli__install__tests__install_nothing.snap
@@ -1,0 +1,5 @@
+---
+source: src/cli/install.rs
+expression: output
+---
+

--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -61,11 +61,10 @@ impl Shell for Bash {
     }
 
     fn set_env(&self, k: &str, v: &str) -> String {
-        format!(
-            "export {k}={v}\n",
-            k = shell_escape::unix::escape(k.into()),
-            v = shell_escape::unix::escape(v.into())
-        )
+        let k = shell_escape::unix::escape(k.into());
+        let v = shell_escape::unix::escape(v.into());
+        let v = v.replace("\\n", "\n");
+        format!("export {k}={v}\n")
     }
 
     fn unset_env(&self, k: &str) -> String {

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -76,11 +76,10 @@ impl Shell for Fish {
     }
 
     fn set_env(&self, k: &str, v: &str) -> String {
-        format!(
-            "set -gx {k} {v}\n",
-            k = shell_escape::unix::escape(k.into()),
-            v = shell_escape::unix::escape(v.into())
-        )
+        let k = shell_escape::unix::escape(k.into());
+        let v = shell_escape::unix::escape(v.into());
+        let v = v.replace("\\n", "\n");
+        format!("set -gx {k} {v}\n")
     }
 
     fn unset_env(&self, k: &str) -> String {

--- a/src/snapshots/rtx__env_diff__tests__from_bash_script.snap
+++ b/src/snapshots/rtx__env_diff__tests__from_bash_script.snap
@@ -9,5 +9,6 @@ EnvDiff {
     new: [
         "ADDED_VAR=added",
         "MODIFIED_VAR=modified",
+        "MULTILINE_VAR=line1\nline2\nline3",
     ],
 }

--- a/test/fixtures/exec-env
+++ b/test/fixtures/exec-env
@@ -3,3 +3,6 @@
 export UNMODIFIED_VAR="unmodified"
 export MODIFIED_VAR="modified"
 export ADDED_VAR="added"
+export MULTILINE_VAR="line1
+line2
+line3"


### PR DESCRIPTION
Fixes #210 

Lua works now:
```
rtx  multiline-env ❯ rtx activate | source
rtx  multiline-env ❯ rtx shell lua@latest
rtx  multiline-env ❯ lua -v
Lua 5.4.4  Copyright (C) 1994-2022 Lua.org, PUC-Rio
```

Before:
```
rtx  main ❯ rtx activate | source
set: package.cpath : invalid variable name. See `help identifiers`

- (line 6):
set -gx 'package.cpath ' ' package.cpath .. '\'';/Users/jdx/.local/share/rtx/installs/lua/5.4.4/lib/lua/5.4/?.so;/Users/jdx/.local/share/rtx/installs/lua/5.4.4/luarocks/lib/lua/5.4/?.so'\'''
^
from sourcing file -
	called on line 17 of file -
in function '__rtx_env_eval'
	called on line 40 of file -
from sourcing file -

(Type 'help set' for related documentation)
rtx  main ❯ rtx shell lua@latest
set: package.cpath : invalid variable name. See `help identifiers`

- (line 1):
set -e 'package.cpath '
^
from sourcing file -
	called on line 17 of file -
in function '__rtx_env_eval'
in event handler: handler for generic event 'fish_prompt'

(Type 'help set' for related documentation)
set: package.cpath : invalid variable name. See `help identifiers`

- (line 12):
set -gx 'package.cpath ' ' package.cpath .. '\'';/Users/jdx/.local/share/rtx/installs/lua/5.4.4/lib/lua/5.4/?.so;/Users/jdx/.local/share/rtx/installs/lua/5.4.4/luarocks/lib/lua/5.4/?.so'\'''
^
from sourcing file -
	called on line 17 of file -
in function '__rtx_env_eval'
in event handler: handler for generic event 'fish_prompt'

(Type 'help set' for related documentation)
rtx  main ❯ lua -v
Lua 5.4.4  Copyright (C) 1994-2022 Lua.org, PUC-Rio
```