### PR TITLE
bug: do not use RTX_EXE in fake-asdf

### DIFF
--- a/src/fake_asdf.rs
+++ b/src/fake_asdf.rs
@@ -16,10 +16,10 @@ fn setup() -> color_eyre::Result<PathBuf> {
             fs::create_dir_all(&path)?;
             fs::write(
                 &asdf_bin,
+                // rtx="${{RTX_EXE:-rtx}}"
                 formatdoc! {r#"
                 #!/bin/sh
-                rtx="${{RTX_EXE:-rtx}}"
-                "$rtx" asdf "$@"
+                rtx asdf "$@"
             "#},
             )?;
             let mut perms = asdf_bin.metadata()?.permissions();


### PR DESCRIPTION
shims would break if `RTX_EXE` pointed to a shim:

```
rtx  main ❯ ~/.rtx/shims/node -v
✔ Select versions to install · nodejs@18.13.0
Trying to update node-build... ok
Downloading node-v18.13.0-darwin-arm64.tar.gz...
-> https://nodejs.org/dist/v18.13.0/node-v18.13.0-darwin-arm64.tar.gz
Installing node-v18.13.0-darwin-arm64...
Installed node-v18.13.0-darwin-arm64 to /Users/jdx/.local/share/rtx/installs/nodejs/18.13.0

[WARN] Tool not installed: nodejs@18.13.0
node:internal/modules/cjs/loader:1093
  throw err;
  ^

Error: Cannot find module '/Users/jdx/src/rtx/asdf'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1090:15)
    at Module._load (node:internal/modules/cjs/loader:934:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12)
    at node:internal/main/run_main_module:23:47 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v19.7.0
rtx nodejs@18.13.0 error ✗                                                             7s
[WARN] Error installing runtimes: [nodejs] script exited with non-zero status: exit code 1
v19.7.0
```

In effect what's happening is fake asdf is running `<SHIM> asdf ...` which becomes `node asdf ...` when it should be `rtx asdf ...`. This changes fake-asdf to just use whichever `rtx` is on PATH.

I believe this will fix it though testing it is kind of hard.