### PR TITLE
README: fixed typo on `rtx shell ` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1336,7 +1336,7 @@ Examples:
   $ rtx settings set shims_dir ~/.rtx/shims
   $ rtx reshim
   $ ~/.rtx/shims/node -v
-  v20.0.0
+  v18.0.0
 ```
 ### `rtx self-update`
 
@@ -1432,7 +1432,7 @@ Arguments:
 Examples:
   $ rtx shell nodejs@18
   $ node -v
-  v20.0.0
+  v18.0.0
 ```
 ### `rtx uninstall`
 

--- a/src/cli/reshim.rs
+++ b/src/cli/reshim.rs
@@ -150,6 +150,6 @@ static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
       $ rtx settings set shims_dir ~/.rtx/shims
       $ rtx reshim
       $ ~/.rtx/shims/node -v
-      v20.0.0
+      v18.0.0
     "#, style("Examples:").bold().underlined()}
 });

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -66,7 +66,7 @@ static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
     {}
       $ rtx shell nodejs@18
       $ node -v
-      v20.0.0
+      v18.0.0
     "#, style("Examples:").bold().underlined()}
 });
 


### PR DESCRIPTION
setting the shell version to 18 should output that node is version 18