### PR TITLE
Fix config file and CLI setting for asdf_compat

### DIFF
--- a/src/cli/settings/set.rs
+++ b/src/cli/settings/set.rs
@@ -30,6 +30,7 @@ impl Command for SettingsSet {
             "legacy_version_file" => parse_bool(&self.value)?,
             "plugin_autoupdate_last_check_duration" => parse_i64(&self.value)?,
             "verbose" => parse_bool(&self.value)?,
+            "asdf_compat" => parse_bool(&self.value)?,
             "jobs" => parse_i64(&self.value)?,
             "shorthands_file" => self.value.into(),
             "disable_default_shorthands" => parse_bool(&self.value)?,

--- a/src/config/config_file/rtxrc.rs
+++ b/src/config/config_file/rtxrc.rs
@@ -98,6 +98,7 @@ impl RTXFile {
                     Some(self.parse_duration_minutes(k, v)?)
             }
             "verbose" => self.settings.verbose = Some(self.parse_bool(k, v)?),
+            "asdf_compat" => self.settings.asdf_compat = Some(self.parse_bool(k, v)?),
             "jobs" => self.settings.jobs = Some(self.parse_usize(k, v)?),
             "shorthands_file" => self.settings.shorthands_file = Some(self.parse_path(k, v)?),
             "disable_default_shorthands" => {


### PR DESCRIPTION
Currently,

`rtx settings ls` lists `asdf_compat` in it and `rtx settings get asdf_compat` returns `false`

but
`rtx settings get asdf_compat true` and `rtx settings get asdf_compat false` fail:

```
Error:
   0: Unknown setting: asdf_compat

Location:
   src/cli/settings/set.rs:37

Version:
   1.18.2 macos-arm64 (built 2023-02-27)

Suggestion: Run with RTX_DEBUG=1 for more information.

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

In fact, manually setting the value for it in `~/.config/rtx/config.toml` as per the README also fails (even if you are just explicitly setting it to the default of `false`):

```
Error:
   0: error loading settings from [...]/.config/rtx/config.toml
   1: error parsing toml
   2: expected plugin to be a string, array, or table, got: true

Location:
   src/config/config_file/rtxrc.rs:161

TOML:
   [asdf_compat]
   true

Version:
   1.18.2 macos-arm64 (built 2023-02-27)

Suggestion: Run with RTX_DEBUG=1 for more information.

Backtrace omitted. Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.
```

This PR fixes both of these situations.