### PR TITLE
chore: disable colors in manpages

### DIFF
--- a/justfile
+++ b/justfile
@@ -75,18 +75,18 @@ lint-fix:
 
 # regenerate README.md
 render-help: build
-    rtx render-help > README.md
+    NO_COLOR=1 rtx render-help > README.md
     ./scripts/gh-md-toc --insert --no-backup --hide-footer --skip-header README.md > /dev/null
 
 # regenerate shell completion files
 render-completions: build
-    rtx complete -s bash > completions/rtx.bash
-    rtx complete -s zsh > completions/_rtx
-    rtx complete -s fish > completions/rtx.fish
+    NO_COLOR=1 rtx complete -s bash > completions/rtx.bash
+    NO_COLOR=1 rtx complete -s zsh > completions/_rtx
+    NO_COLOR=1 rtx complete -s fish > completions/rtx.fish
 
 # regenerate manpages
 render-mangen: build
-    rtx mangen
+    NO_COLOR=1 rtx mangen
 
 # called by husky precommit hook
 pre-commit: render-help render-completions render-mangen

--- a/man/man1/rtx.1
+++ b/man/man1/rtx.1
@@ -113,7 +113,7 @@ shows the plugin that a bin points to
 rtx\-help(1)
 Print this message or the help of the given subcommand(s)
 .SH EXTRA
-[1m[4mExamples:[0m
+Examples:
   rtx install nodejs@18.0.0       Install a specific node version
   rtx install nodejs@18.0         Install a version matching a prefix
   rtx local nodejs@18             Use node\-18.x in current project

--- a/src/cli/mangen.rs
+++ b/src/cli/mangen.rs
@@ -13,7 +13,9 @@ pub struct Mangen {}
 
 impl Command for Mangen {
     fn run(self, _config: Config, _out: &mut Output) -> Result<()> {
-        let cli = Cli::command().version(env!("CARGO_PKG_VERSION"));
+        let cli = Cli::command()
+            .version(env!("CARGO_PKG_VERSION"))
+            .disable_colored_help(true);
 
         let man = clap_mangen::Man::new(cli);
         let mut buffer: Vec<u8> = Default::default();


### PR DESCRIPTION
<!-- Note that the coverage and E2E tests will likely fail for you on CI due to the GITHUB_API_KEY secret not being found. See CONTRIBUTING.MD for more information. -->
