### PR TITLE
Fix readme shims_dir config name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1625,7 +1625,7 @@ To support this, there is experimental support for using rtx in a "shim" mode. T
 
 ```
 $ rtx settings set experimental true
-$ rtx settings set shim_dir ~/.rtx/shims
+$ rtx settings set shims_dir ~/.rtx/shims
 $ rtx i nodejs@18.0.0
 $ rtx reshim
 $ ~/.rtx/shims/node -v

--- a/src/cli/render_help.rs
+++ b/src/cli/render_help.rs
@@ -755,7 +755,7 @@ To support this, there is experimental support for using rtx in a "shim" mode. T
 
 ```
 $ rtx settings set experimental true
-$ rtx settings set shim_dir ~/.rtx/shims
+$ rtx settings set shims_dir ~/.rtx/shims
 $ rtx i nodejs@18.0.0
 $ rtx reshim
 $ ~/.rtx/shims/node -v


### PR DESCRIPTION
<!-- Note that the coverage and E2E tests will likely fail for you on CI due to the GITHUB_API_KEY secret not being found. See CONTRIBUTING.MD for more information. -->
