### PR TITLE
chore: use GITHUB_TOKEN for E2E tests

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,1 +1,0 @@
-<!-- Note that the coverage and E2E tests will likely fail for you on CI due to the GITHUB_API_KEY secret not being found. See CONTRIBUTING.MD for more information. -->

--- a/.github/workflows/rtx.yml
+++ b/.github/workflows/rtx.yml
@@ -30,7 +30,6 @@ jobs:
       - name: Run cargo nextest
         run: cargo nextest run --features clap_mangen
         env:
-          GITHUB_API_TOKEN: ${{ secrets.RTX_GITHUB_BOT_TOKEN }}
           RUST_BACKTRACE: "1"
       - run: just lint
 
@@ -53,7 +52,7 @@ jobs:
       - name: Run tests with coverage
         uses: nick-fields/retry@v2
         env:
-          GITHUB_API_TOKEN: ${{ secrets.RTX_GITHUB_BOT_TOKEN }}
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUST_BACKTRACE: "1"
         with:
           timeout_minutes: 20
@@ -136,7 +135,7 @@ jobs:
       - name: Run e2e tests
         uses: nick-fields/retry@v2
         env:
-          GITHUB_API_TOKEN: ${{ secrets.RTX_GITHUB_BOT_TOKEN }}
+          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUST_BACKTRACE: "1"
         with:
           timeout_minutes: 20


### PR DESCRIPTION
This secret should be available on forks so external
contributors should now have passing E2E tests
