### PR TITLE
shell unset

### DIFF
--- a/.bin/rtx
+++ b/.bin/rtx
@@ -2,4 +2,4 @@
 set -e
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-cargo run --all-features --manifest-path "$SCRIPT_DIR/../Cargo.toml" -- "$@"
+cargo run -q --all-features --manifest-path "$SCRIPT_DIR/../Cargo.toml" -- "$@"

--- a/README.md
+++ b/README.md
@@ -1620,11 +1620,15 @@ Sets a tool version for the current shell session
 
 Only works in a session where rtx is already activated.
 
-Usage: shell [RUNTIME]...
+Usage: shell [OPTIONS] [RUNTIME]...
 
 Arguments:
   [RUNTIME]...
           Runtime version(s) to use
+
+Options:
+  -u, --unset
+          Removes a previously set version
 
 Examples:
   $ rtx shell nodejs@18

--- a/completions/_rtx
+++ b/completions/_rtx
@@ -1099,6 +1099,8 @@ default: 4]: : ' \
 '--jobs=[Number of plugins and runtimes to install in parallel
 default: 4]: : ' \
 '--log-level=[Set the log output verbosity]:LEVEL: ' \
+'-u[Removes a previously set version]' \
+'--unset[Removes a previously set version]' \
 '-r[Directly pipe stdin/stdout/stderr to user.
 sets --jobs=1]' \
 '--raw[Directly pipe stdin/stdout/stderr to user.

--- a/completions/rtx.bash
+++ b/completions/rtx.bash
@@ -2777,7 +2777,7 @@ _rtx() {
             return 0
             ;;
         rtx__shell)
-            opts="-j -r -v -h --jobs --log-level --raw --verbose --help [RUNTIME]..."
+            opts="-u -j -r -v -h --unset --jobs --log-level --raw --verbose --help [RUNTIME]..."
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/rtx.fish
+++ b/completions/rtx.fish
@@ -431,6 +431,7 @@ complete -c rtx -n "__fish_seen_subcommand_from settings; and __fish_seen_subcom
 complete -c rtx -n "__fish_seen_subcommand_from shell" -s j -l jobs -d 'Number of plugins and runtimes to install in parallel
 default: 4' -r
 complete -c rtx -n "__fish_seen_subcommand_from shell" -l log-level -d 'Set the log output verbosity' -r
+complete -c rtx -n "__fish_seen_subcommand_from shell" -s u -l unset -d 'Removes a previously set version'
 complete -c rtx -n "__fish_seen_subcommand_from shell" -s r -l raw -d 'Directly pipe stdin/stdout/stderr to user.
 sets --jobs=1'
 complete -c rtx -n "__fish_seen_subcommand_from shell" -s v -l verbose -d 'Show installation output'

--- a/src/cli/shell.rs
+++ b/src/cli/shell.rs
@@ -24,6 +24,10 @@ pub struct Shell {
     /// Runtime version(s) to use
     #[clap(value_parser = RuntimeArgParser)]
     runtime: Vec<RuntimeArg>,
+
+    /// Removes a previously set version
+    #[clap(long, short)]
+    unset: bool,
 }
 
 impl Command for Shell {
@@ -41,7 +45,12 @@ impl Command for Shell {
             let source = &ts.versions.get(&rtv.plugin.name).unwrap().source;
             if matches!(source, ToolSource::Argument) {
                 let k = format!("RTX_{}_VERSION", rtv.plugin.name.to_uppercase());
-                rtxprintln!(out, "{}", shell.set_env(&k, &rtv.version));
+                let op = if self.unset {
+                    shell.unset_env(&k)
+                } else {
+                    shell.set_env(&k, &rtv.version)
+                };
+                out.stdout.writeln(op);
             }
         }
         touch_dir(&dirs::ROOT)?;


### PR DESCRIPTION
- better support for .rtx.toml in local/global commands
- feat: added `rtx shell --unset`
