### PR TITLE
feat: dockerize dev setup

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,26 @@
+FROM mcr.microsoft.com/devcontainers/rust:0-1-bullseye
+
+WORKDIR /workspaces/cached
+
+# Use another target directory to avoid conflicts with the host target directory
+RUN mkdir /workspaces/target
+ENV CARGO_TARGET_DIR=/workspaces/target
+
+# Install rust tools
+RUN rustup component add clippy llvm-tools rustfmt
+RUN cargo install cargo-insta cargo-llvm-cov
+
+# Install dependencies
+RUN export DEBIAN_FRONTEND=noninteractive \
+    && curl -fsSL https://deb.nodesource.com/setup_18.x | bash - \
+    && apt-get update \
+    && apt-get -y install --no-install-recommends \
+    # shells, direnv, shellcheck
+    bash fish zsh direnv nodejs shellcheck \
+    && apt-get clean \
+    # shfmt
+    && curl -sS https://webi.sh/shfmt | sh \
+    # just
+    && curl --proto '=https' --tlsv1.2 -sSf https://just.systems/install.sh | bash -s -- --to /usr/bin
+
+ENTRYPOINT [ "/bin/bash" ]

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/rust
+{
+    "name": "Rust",
+
+    // "image": "mcr.microsoft.com/devcontainers/rust:0-1-bullseye",
+
+    // Or use a Dockerfile or Docker Compose file. More info: https://containers.dev/guide/dockerfile
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+
+    // Use 'mounts' to make the cargo cache persistent in a Docker Volume.
+    // "mounts": [
+    // 	{
+    // 		"source": "devcontainer-cargo-cache-${devcontainerId}",
+    // 		"target": "/usr/local/cargo",
+    // 		"type": "volume"
+    // 	}
+    // ]
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+    // "features": {},
+
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
+
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "rustc --version",
+
+    // Configure tool-specific properties.
+    // "customizations": {},
+
+    // Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+    "remoteUser": "root"
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,19 @@
+# Contributing
+
+## Development Container
+
+The directory `.devcontainer` contains a Dockerfile that can be used to build a container for local development. This is useful if you want to use either VSCode's remote container feature or a standalone container to develop rtx. To use it, you'll need to have Docker Desktop installed and running.
+
+Build and run the container with the following commands:
+
+```shell
+cd .devcontainer
+docker build  -t local/rtxdevcontainer .
+docker run --rm -it -v "$(pwd)"/../:/workspaces/cached local/rtxdevcontainer
+```
+
+To use the container with VSCode, you'll need to install the [Remote - Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) extension. Once installed, you can open the project in a container by opening the Command Palette (F1) and selecting "Remote-Containers: Open Folder in Container...". Select the root of the rtx project and the container will be built and started.
+
 ## Dependencies
 
 * [rust](https://www.rust-lang.org/) stable 1.66.1+ (it might be compatible with earlier, but I haven't tested that). As of this writing: 1.67.0 but GH actions will use the latest stable whenever it runs.

--- a/e2e/run_all_tests
+++ b/e2e/run_all_tests
@@ -3,11 +3,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" &>/dev/null && pwd)"
 
 ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-FILES=$(find e2e -name 'test_*' -type f | sort)
+FILES=$(find e2e -name 'test_*' -type f -not -path "*/.rtx/*" | sort)
 for f in $FILES; do
-  if [[ "$f" == "e2e/.rtx/"* ]]; then
-    continue
-  fi
   "$ROOT/e2e/run_test" "$f"
   echo
 done

--- a/src/cli/direnv/envrc.rs
+++ b/src/cli/direnv/envrc.rs
@@ -74,6 +74,11 @@ mod tests {
         let stdout = assert_cli!("direnv", "envrc");
         let envrc = fs::read_to_string(stdout.trim()).unwrap();
         let envrc = envrc.replace(dirs::HOME.to_string_lossy().as_ref(), "~");
+        let envrc = envrc
+            .lines()
+            .filter(|l| !l.starts_with("export REMOTE_"))
+            .collect::<Vec<_>>()
+            .join("\n");
         assert_display_snapshot!(envrc);
     }
 }


### PR DESCRIPTION
Gave this a try but this obviously still needs work. 

```bash
cd .devcontainer
docker build -t local/rtxdevcontainer .
docker run --rm -it -v "$(pwd)"/../:/workspaces/cached local/rtxdevcontainer
```

Mounting the project caused some trouble regarding the CARGO_TARGRET_DIR that clashes with the host which might be of another architecture and therefore causes linking issues etc.

Running in VS Code Dev Containers or plain docker gives mixed results. VS Code adds some environment variables of its own which troubles some tests. Other tests are failing because of different plugin installation paths. Also E2E fail because they can't find the generated `rtx` binary (seems it does not use CARGO_TARGET_DIR/debug/rtx).
