### PR TITLE
Fix zsh deactivation

### DIFF
--- a/src/cli/snapshots/rtx__cli__deactivate__tests__deactivate-2.snap
+++ b/src/cli/snapshots/rtx__cli__deactivate__tests__deactivate-2.snap
@@ -3,8 +3,8 @@ source: src/cli/deactivate.rs
 expression: output
 ---
 export PATH='$PATH'
-precmd_functions=( ${precmd_functions[(r)_rtx_hook]} )
-chpwd_functions=( ${chpwd_functions[(r)_rtx_hook]} )
+precmd_functions=( ${precmd_functions:#_rtx_hook} )
+chpwd_functions=( ${chpwd_functions:#_rtx_hook} )
 unset -f _rtx_hook
 unset -f rtx
 unset RTX_SHELL

--- a/src/shell/snapshots/rtx__shell__zsh__tests__deactivate.snap
+++ b/src/shell/snapshots/rtx__shell__zsh__tests__deactivate.snap
@@ -2,8 +2,8 @@
 source: src/shell/zsh.rs
 expression: replace_path(&deactivate)
 ---
-precmd_functions=( ${precmd_functions[(r)_rtx_hook]} )
-chpwd_functions=( ${chpwd_functions[(r)_rtx_hook]} )
+precmd_functions=( ${precmd_functions:#_rtx_hook} )
+chpwd_functions=( ${chpwd_functions:#_rtx_hook} )
 unset -f _rtx_hook
 unset -f rtx
 unset RTX_SHELL

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -62,8 +62,8 @@ impl Shell for Zsh {
 
     fn deactivate(&self) -> String {
         formatdoc! {r#"
-        precmd_functions=( ${{precmd_functions[(r)_rtx_hook]}} )
-        chpwd_functions=( ${{chpwd_functions[(r)_rtx_hook]}} )
+        precmd_functions=( ${{precmd_functions:#_rtx_hook}} )
+        chpwd_functions=( ${{chpwd_functions:#_rtx_hook}} )
         unset -f _rtx_hook
         unset -f rtx
         unset RTX_SHELL


### PR DESCRIPTION
Turns out the existing `rtx deactivate` doesn't actually work as expected. In particular, instead of removing `_rtx_hook`, it was actually removing everything _except_ `_rtx_hook` from the `precmd_functions` and `chpwd_functions`.

This commit fixes this.

Relevant documentation from zsh (https://zsh.sourceforge.io/Guide/zshguide05.html)
> The `(r)` flag takes a pattern and substitutes the first element of the array matched [...]

and

From https://zsh.sourceforge.io/Doc/Release/Expansion.html#Parameter-Expansion:
> `${name:#pattern}`
> [...] If `name` is an array the matching array elements are removed