### PR TITLE
chore: use RTX_GITHUB_BOT_TOKEN if available for coverage tests

### DIFF
--- a/.github/workflows/rtx.yml
+++ b/.github/workflows/rtx.yml
@@ -54,6 +54,7 @@ jobs:
         uses: nick-fields/retry@v2
         env:
           GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RTX_GITHUB_BOT_TOKEN: ${{ secrets.RTX_GITHUB_BOT_TOKEN }}
           RUST_BACKTRACE: "1"
         with:
           timeout_minutes: 20
@@ -136,7 +137,6 @@ jobs:
       - name: Run e2e tests
         uses: nick-fields/retry@v2
         env:
-          GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           RUST_BACKTRACE: "1"
         with:
           timeout_minutes: 20

--- a/justfile
+++ b/justfile
@@ -37,7 +37,11 @@ test-coverage:
     #!/usr/bin/env bash
     set -euxo pipefail
     source <(cargo llvm-cov show-env --export-prefix) 
-    cargo llvm-cov clean --workspace 
+    cargo llvm-cov clean --workspace
+
+    if [[ -n "${RTX_GITHUB_BOT_TOKEN:-}" ]]; then
+    	export GITHUB_API_TOKEN="$RTX_GITHUB_BOT_TOKEN"
+    fi
 
     cargo test --features clap_mangen
     cargo build --all-features


### PR DESCRIPTION
This is needed for the self_update check. GITHUB_TOKEN can be rate limited, but RTX_GITHUB_BOT_TOKEN will not be available on forks
