### PR TITLE
bug: fix environment variables escaping (#288)

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,0 @@
-coverage:
-  status:
-    project:
-      default:
-        target: 80%
-        informational: true

--- a/src/env_diff.rs
+++ b/src/env_diff.rs
@@ -325,7 +325,22 @@ mod tests {
             "UNMODIFIED_SQUOTE_VAR" => "hello\\'world",
             "UNMODIFIED_ESCAPE_VAR" => "hello\\world",
             "MODIFIED_VAR" => "original",
-            "ESCAPES" => "\\n\\t\\r\\v\\f\\a\\b\\e\\0\\x1b\\u1234\\U00012345\\a\\b\\e\\E\\f\\n\\r\\t\\v\"\\?`$\\g",
+            "ESCAPES" => "\\n\\t\\r\\v\\f\\a\\b\\e\\0\\x1b\\u1234\\U00012345\\a\\b\\e\\E\\f\\n\\r\\t\\v\"?`$\\g'\\0",
+            "BACKSPACE" => "\u{08}",
+            "BACKTICK" => "`",
+            "BELL" => "\u{07}",
+            "CARRIAGE_RETURN" => "\r",
+            "DOLLAR" => "$",
+            "DOUBLE_QUOTE" => "\"",
+            "ESCAPE" => "\u{1b}",
+            "ESCAPE2" => "\u{1b}",
+            "FORM_FEED" => "\u{0c}",
+            "G" => "g",
+            "NEWLINE" => "\n",
+            "QUESTION_MARK" => "?",
+            "SINGLE_QUOTE" => "'",
+            "TAB" => "\t",
+            "VERTICAL_TAB" => "\u{0b}",
         }
         .into_iter()
         .map(|(k, v)| (k.into(), v.into()))

--- a/src/env_diff.rs
+++ b/src/env_diff.rs
@@ -78,91 +78,34 @@ impl EnvDiff {
         .read()?;
 
         let mut additions = HashMap::new();
-        let mut lines = out.lines();
-
-        let mut current_key = "";
-        let mut current_value = String::new();
-        let mut line = lines.next();
-        loop {
-            let mut flush = true;
-            match line {
-                Some(current_line) => {
-                    match current_line.strip_prefix("declare -x ") {
-                        Some(current_line) => {
-                            let v: &str;
-                            (current_key, v) = current_line.split_once('=').unwrap_or_default();
-                            if valid_key(current_key) {
-                                line = lines.next();
-                                continue;
-                            }
-
-                            current_value = String::from(v);
-
-                            // check if we are dealing with a multiline
-                            line = lines.next();
-                            match line {
-                                Some(next_line) => {
-                                    if !next_line.starts_with("declare -x ") {
-                                        // multiline do not flush values
-                                        flush = false;
-                                    }
-                                }
-                                None => (),
-                            }
-
-                            if flush {
-                                if let Some(orig) = env.get(current_key) {
-                                    if &current_value != orig {
-                                        additions.insert(
-                                            current_key.to_string(),
-                                            Self::normalize_escape_sequences(&current_value),
-                                        );
-                                    }
-                                } else {
-                                    additions.insert(
-                                        current_key.to_string(),
-                                        Self::normalize_escape_sequences(&current_value),
-                                    );
-                                }
-                            }
-                        }
-                        None => {
-                            current_value.push_str("\n");
-                            current_value.push_str(current_line);
-
-                            // check if we are done with multiline
-                            line = lines.next();
-                            match line {
-                                Some(next_line) => {
-                                    if !next_line.starts_with("declare -x ") {
-                                        // multiline do not flush values
-                                        flush = false;
-                                    }
-                                }
-                                None => (),
-                            }
-                            if flush {
-                                if let Some(orig) = env.get(current_key) {
-                                    if &current_value != orig {
-                                        additions.insert(
-                                            current_key.to_string(),
-                                            Self::normalize_escape_sequences(&current_value),
-                                        );
-                                    }
-                                } else {
-                                    additions.insert(
-                                        current_key.to_string(),
-                                        Self::normalize_escape_sequences(&current_value),
-                                    );
-                                }
-                            }
-                        }
+        let mut cur_key = None;
+        for line in out.lines() {
+            match line.strip_prefix("declare -x ") {
+                Some(line) => {
+                    let (k, v) = line.split_once('=').unwrap_or_default();
+                    if valid_key(k) {
+                        continue;
                     }
+                    cur_key = Some(k.to_string());
+                    additions.insert(k.to_string(), v.to_string());
                 }
                 None => {
-                    break;
+                    if let Some(k) = &cur_key {
+                        let v = format!("\n{}", line);
+                        additions.get_mut(k).unwrap().push_str(&v);
+                    }
                 }
             }
+        }
+        for (k, v) in additions.clone().iter() {
+            let v = normalize_escape_sequences(v);
+            if let Some(orig) = env.get(k) {
+                if &v == orig {
+                    additions.remove(k);
+                    continue;
+                }
+            }
+            additions.insert(k.into(), v);
         }
 
         Ok(Self::new(&env, additions))
@@ -209,53 +152,6 @@ impl EnvDiff {
             path: self.path.clone(),
         }
     }
-
-    fn normalize_escape_sequences(input: &str) -> String {
-        let input = if input.starts_with('"') && input.ends_with('"') {
-            input[1..input.len() - 1].to_string()
-        } else if input.starts_with("$'") && input.ends_with('\'') {
-            input[2..input.len() - 1].to_string()
-        } else {
-            input.to_string()
-        };
-
-        let mut result = String::with_capacity(input.len());
-        let mut chars = input.chars().enumerate();
-
-        while let Some((_, c)) = chars.next() {
-            if c == '\\' {
-                match chars.next() {
-                    Some((_, val)) => match val {
-                        'a' => result.push('\u{07}'),
-                        'b' => result.push('\u{08}'),
-                        'e' | 'E' => result.push('\u{1b}'),
-                        'f' => result.push('\u{0c}'),
-                        'n' => result.push('\n'),
-                        'r' => result.push('\r'),
-                        't' => result.push('\t'),
-                        'v' => result.push('\u{0b}'),
-                        '\\' => result.push('\\'),
-                        '\'' => result.push('\''),
-                        '"' => result.push('"'),
-                        '?' => result.push('?'),
-                        '`' => result.push('`'),
-                        '$' => result.push('$'),
-                        _ => {
-                            result.push('\\');
-                            result.push(val);
-                        }
-                    },
-                    None => {
-                        error!("Invalid escape sequence");
-                    }
-                }
-            } else {
-                result.push(c)
-            }
-        }
-
-        result
-    }
 }
 
 fn valid_key(k: &str) -> bool {
@@ -300,6 +196,53 @@ impl Debug for EnvDiff {
             .field("new", &print_sorted(&self.new))
             .finish()
     }
+}
+
+fn normalize_escape_sequences(input: &str) -> String {
+    let input = if input.starts_with('"') && input.ends_with('"') {
+        input[1..input.len() - 1].to_string()
+    } else if input.starts_with("$'") && input.ends_with('\'') {
+        input[2..input.len() - 1].to_string()
+    } else {
+        input.to_string()
+    };
+
+    let mut result = String::with_capacity(input.len());
+    let mut chars = input.chars();
+
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some(val) => match val {
+                    'a' => result.push('\u{07}'),
+                    'b' => result.push('\u{08}'),
+                    'e' | 'E' => result.push('\u{1b}'),
+                    'f' => result.push('\u{0c}'),
+                    'n' => result.push('\n'),
+                    'r' => result.push('\r'),
+                    't' => result.push('\t'),
+                    'v' => result.push('\u{0b}'),
+                    '\\' => result.push('\\'),
+                    '\'' => result.push('\''),
+                    '"' => result.push('"'),
+                    '?' => result.push('?'),
+                    '`' => result.push('`'),
+                    '$' => result.push('$'),
+                    _ => {
+                        result.push('\\');
+                        result.push(val);
+                    }
+                },
+                None => {
+                    error!("Invalid escape sequence");
+                }
+            }
+        } else {
+            result.push(c)
+        }
+    }
+
+    result
 }
 
 #[cfg(test)]
@@ -383,6 +326,7 @@ mod tests {
             "UNMODIFIED_SQUOTE_VAR" => "hello\\'world",
             "UNMODIFIED_ESCAPE_VAR" => "hello\\world",
             "MODIFIED_VAR" => "original",
+            "ESCAPES" => "\\n\\t\\r\\v\\f\\a\\b\\e\\0\\x1b\\u1234\\U00012345\\a\\b\\e\\E\\f\\n\\r\\t\\v\"\\?`$\\g",
         }
         .into_iter()
         .map(|(k, v)| (k.into(), v.into()))

--- a/test/fixtures/exec-env
+++ b/test/fixtures/exec-env
@@ -9,3 +9,4 @@ export ADDED_VAR="added"
 export MULTILINE_VAR="line1
 line2
 line3"
+export ESCAPES="\\n\\t\\r\\v\\f\\a\\b\\e\\0\\x1b\\u1234\\U00012345\a\b\e\E\f\n\r\t\v\"\?\`\$\g"

--- a/test/fixtures/exec-env
+++ b/test/fixtures/exec-env
@@ -9,4 +9,21 @@ export ADDED_VAR="added"
 export MULTILINE_VAR="line1
 line2
 line3"
-export ESCAPES="\\n\\t\\r\\v\\f\\a\\b\\e\\0\\x1b\\u1234\\U00012345\a\b\e\E\f\n\r\t\v\"\?\`\$\g"
+export ESCAPES="\\n\\t\\r\\v\\f\\a\\b\\e\\0\\x1b\\u1234\\U00012345\a\b\e\E\f\n\r\t\v\"?\`\$\g'\0"
+export BELL=$'\a'
+export BACKSPACE=$'\b'
+export ESCAPE=$'\e'
+export ESCAPE2=$'\E'
+export FORM_FEED=$'\f'
+export NEWLINE=$'\n'
+export CARRIAGE_RETURN=$'\r'
+export TAB=$'\t'
+export VERTICAL_TAB=$'\v'
+export DOUBLE_QUOTE=$'"'
+export SINGLE_QUOTE=$"'"
+export QUESTION_MARK=$'?'
+export BACKTICK=$'`'
+export DOLLAR=$'$'
+export G=$'g'
+
+unexported="unexported val"


### PR DESCRIPTION
Added a function to escape environment variables (see normalize_escape_sequences). It is mainly based on [ansi-c escape sequences](https://en.wikipedia.org/wiki/Escape_sequences_in_C#Table_of_escape_sequences) plus some extra chars ('`', '$'), these  were escaped by bash in my current environment.

I also rewrote the bash script output parsing to escape the values after parsing (mainly  for multiline variables).

**Unit tests**
The unit test were failing in my environment due to the original escaping method. They all now succeed.
I have modified one value in 'test_from_bash_script' which looks that it was incorrectly escaped.
