### PR TITLE
feat: added new syntax for subtracting versions, e.g.: `nodejs@18!-2` to install node-16.x

### DIFF
--- a/.rtx.toml
+++ b/.rtx.toml
@@ -2,7 +2,7 @@
 FOO = "bar"
 
 [tools]
-nodejs = '18'
+nodejs = 'lts'
 tiny = {version="1", foo="bar"}
 golang = {version="latest", foo="bar"}
 python = {version="latest", virtualenv="$HOME/.cache/venv"}

--- a/e2e/test_bang
+++ b/e2e/test_bang
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+assert() {
+  local actual
+  actual="$($*)"
+  if [[ "$actual" != "$2" ]]; then
+    echo "Expected '$2' but got '$actual'"
+    exit 1
+  fi
+}
+
+assert "rtx x nodejs@18.0.0!-2 -- node -v" "v16.0.0"


### PR DESCRIPTION
this makes it easy to express something like "I want the latest 2 lts releases of node":

```
rtx i nodejs@lts nodejs@lts!-2
```