### PR TITLE
feat: support for PATH in .rtx.toml env vars

### DIFF
--- a/e2e/.e2e.rtx.toml
+++ b/e2e/.e2e.rtx.toml
@@ -1,5 +1,6 @@
 [env]
 FOO = "bar"
+PATH = ["/root", "./cwd", "$PATH"]
 
 [tools]
 tiny = "latest"

--- a/e2e/test_local
+++ b/e2e/test_local
@@ -22,6 +22,7 @@ assert_raises "rtx uninstall shfmt@3.6.0"
 
 assert "rtx local" "[env]
 FOO = \"bar\"
+PATH = [\"/root\", \"./cwd\", \"\$PATH\"]
 
 [tools]
 tiny = \"latest\"
@@ -30,6 +31,7 @@ tiny = \"latest\"
 
 assert "rtx local shfmt@3.5.0" "[env]
 FOO = \"bar\"
+PATH = [\"/root\", \"./cwd\", \"\$PATH\"]
 
 [tools]
 tiny = \"latest\"
@@ -44,6 +46,7 @@ fi
 
 assert "rtx local shfmt@3.6.0" "[env]
 FOO = \"bar\"
+PATH = [\"/root\", \"./cwd\", \"\$PATH\"]
 
 [tools]
 tiny = \"latest\"
@@ -58,6 +61,7 @@ fi
 
 assert "rtx local --rm shfmt" "[env]
 FOO = \"bar\"
+PATH = [\"/root\", \"./cwd\", \"\$PATH\"]
 
 [tools]
 tiny = \"latest\"

--- a/src/config/config_file/legacy_version.rs
+++ b/src/config/config_file/legacy_version.rs
@@ -45,6 +45,10 @@ impl ConfigFile for LegacyVersionFile {
         HashMap::new()
     }
 
+    fn path_dirs(&self) -> Vec<PathBuf> {
+        vec![]
+    }
+
     fn remove_plugin(&mut self, _plugin_name: &PluginName) {
         unimplemented!()
     }

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 use std::fmt::{Debug, Display};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 use color_eyre::eyre::{eyre, Result};
 
@@ -33,6 +33,7 @@ pub trait ConfigFile: Debug + Display + Send + Sync {
     fn get_path(&self) -> &Path;
     fn plugins(&self) -> HashMap<PluginName, String>;
     fn env(&self) -> HashMap<String, String>;
+    fn path_dirs(&self) -> Vec<PathBuf>;
     fn remove_plugin(&mut self, plugin_name: &PluginName);
     fn replace_versions(&mut self, plugin_name: &PluginName, versions: &[String]);
     fn save(&self) -> Result<()>;

--- a/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__env-3.snap
+++ b/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__env-3.snap
@@ -1,0 +1,7 @@
+---
+source: src/config/config_file/rtx_toml.rs
+expression: cf
+---
+[env]
+foo="bar"
+

--- a/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__path_dirs-2.snap
+++ b/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__path_dirs-2.snap
@@ -1,0 +1,8 @@
+---
+source: src/config/config_file/rtx_toml.rs
+expression: cf
+---
+[env]
+foo="bar"
+PATH=["/foo", "./bar", "$PATH"]
+

--- a/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__path_dirs-3.snap
+++ b/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__path_dirs-3.snap
@@ -1,0 +1,8 @@
+---
+source: src/config/config_file/rtx_toml.rs
+expression: cf
+---
+[env]
+foo="bar"
+PATH=["/foo", "./bar", "$PATH"]
+

--- a/src/config/config_file/tool_versions.rs
+++ b/src/config/config_file/tool_versions.rs
@@ -155,6 +155,10 @@ impl ConfigFile for ToolVersions {
         HashMap::new()
     }
 
+    fn path_dirs(&self) -> Vec<PathBuf> {
+        vec![]
+    }
+
     fn remove_plugin(&mut self, plugin: &PluginName) {
         self.plugins.remove(plugin);
     }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -40,6 +40,7 @@ pub struct Config {
     pub config_files: ConfigMap,
     pub plugins: IndexMap<PluginName, Arc<Plugin>>,
     pub env: IndexMap<String, String>,
+    pub path_dirs: Vec<PathBuf>,
     pub aliases: AliasMap,
     pub all_aliases: OnceCell<AliasMap>,
     pub should_exit_early: bool,
@@ -97,6 +98,7 @@ impl Config {
 
         let config = Self {
             env: load_env(&config_files),
+            path_dirs: load_path_dirs(&config_files),
             aliases: load_aliases(&config_files),
             all_aliases: OnceCell::new(),
             shorthands: OnceCell::new(),
@@ -427,6 +429,14 @@ fn load_env(config_files: &IndexMap<PathBuf, Box<dyn ConfigFile>>) -> IndexMap<S
         env.extend(cf.env());
     }
     env
+}
+
+fn load_path_dirs(config_files: &IndexMap<PathBuf, Box<dyn ConfigFile>>) -> Vec<PathBuf> {
+    let mut path_dirs = vec![];
+    for cf in config_files.values().rev() {
+        path_dirs.extend(cf.path_dirs());
+    }
+    path_dirs
 }
 
 fn load_aliases(config_files: &IndexMap<PathBuf, Box<dyn ConfigFile>>) -> AliasMap {

--- a/src/toolset/mod.rs
+++ b/src/toolset/mod.rs
@@ -274,7 +274,7 @@ impl Toolset {
     }
     pub fn path_env(&self, config: &Config) -> String {
         let installs = self.list_paths(config);
-        join_paths([installs, env::PATH.clone()].concat())
+        join_paths([config.path_dirs.clone(), installs, env::PATH.clone()].concat())
             .unwrap()
             .to_string_lossy()
             .into()


### PR DESCRIPTION
This makes it so you can add new directories to PATH in .rtx.toml. This is done by specifying PATH as an array like the following:

```toml
[env]
PATH = [
  "/foo",  # absolute path
  "./bar", # relative to the directory .rtx.toml is in
  "$PATH" # for now this is required to be at the end
]
```