### PR TITLE
test: do not require git to run unit tests

### DIFF
--- a/src/cli/plugins/ls.rs
+++ b/src/cli/plugins/ls.rs
@@ -66,8 +66,8 @@ mod tests {
     use pretty_assertions::assert_str_eq;
 
     use crate::cli::tests::grep;
-    use crate::git::Git;
-    use crate::{assert_cli, assert_cli_snapshot, dirs};
+
+    use crate::{assert_cli, assert_cli_snapshot};
 
     #[test]
     fn test_plugin_list() {
@@ -77,12 +77,7 @@ mod tests {
     #[test]
     fn test_plugin_list_urls() {
         let stdout = assert_cli!("plugin", "list", "--urls");
-        let git = Git::new(dirs::CURRENT.clone());
-        let cur_remote = git.get_remote_url().unwrap();
-        assert_str_eq!(
-            grep(stdout, "dummy"),
-            "dummy                         ".to_owned() + cur_remote.as_str()
-        );
+        assert!(stdout.contains("dummy"))
     }
 
     #[test]

--- a/src/cli/prune.rs
+++ b/src/cli/prune.rs
@@ -82,13 +82,13 @@ static AFTER_LONG_HELP: Lazy<String> = Lazy::new(|| {
 
 #[cfg(test)]
 mod tests {
-    use crate::{assert_cli, cmd};
+    use crate::assert_cli;
 
     #[test]
     fn test_prune() {
         assert_cli!("prune", "--dry-run");
         assert_cli!("prune", "tiny");
         assert_cli!("prune");
-        cmd!("git", "checkout", "../data").run().unwrap();
+        assert_cli!("install");
     }
 }


### PR DESCRIPTION
this is helpful for running in docker or places where we have a tarball of the code and not the repo