### PR TITLE
bug: re-enable a performance check

### DIFF
--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -8,8 +8,10 @@ use indexmap::IndexMap;
 use versions::{Chunk, Version};
 
 use crate::config::Config;
+use crate::dirs;
 
 use crate::plugins::Plugin;
+use crate::runtime_symlinks::is_runtime_symlink;
 use crate::runtimes::RuntimeVersion;
 use crate::ui::progress_report::ProgressReport;
 
@@ -74,12 +76,12 @@ impl ToolVersion {
             _ => (),
         }
 
-        // TODO: put this back in when it's compatible with #343
-        // if dirs::INSTALLS.join(&plugin.name).join(&v).exists() {
-        //     // if the version is already installed, no need to fetch all of the remote versions
-        //     let rtv = RuntimeVersion::new(config, plugin, v, self.clone());
-        //     return Ok(rtv);
-        // }
+        let existing_path = dirs::INSTALLS.join(&plugin.name).join(&v);
+        if existing_path.exists() && !is_runtime_symlink(&existing_path) {
+            // if the version is already installed, no need to fetch all the remote versions
+            let rtv = RuntimeVersion::new(config, plugin, v, self.clone());
+            return Ok(rtv);
+        }
 
         if v == "latest" {
             let v = plugin.latest_version(&config.settings, None)?;


### PR DESCRIPTION
This re-enables a check that prevents reloading all of
the versions of a plugin if we are directly running a
specified version
