### PR TITLE
fix: Use tool "as-is" when using "system" version

### DIFF
--- a/src/runtimes.rs
+++ b/src/runtimes.rs
@@ -202,6 +202,9 @@ impl RuntimeVersion {
     }
 
     pub fn exec_env(&self) -> Result<&HashMap<String, String>> {
+        if self.version.as_str() == "system" {
+            return Ok(&*EMPTY_HASH_MAP);
+        }
         if !self.script_man.script_exists(&ExecEnv) || *env::__RTX_SCRIPT {
             // if the script does not exist or we're running from within a script already
             // the second is to prevent infinite loops


### PR DESCRIPTION
When using system version of some tools (`golang`, `java`, etc.), some env variables are set to bad values (`GOROOT` being set to `$HOME/.local/share/rtx/installs/golang/system` for example)

This patch aim to fix that by adopting the same behaviour as `asdf` by not setting env when using "system" tool versions: https://github.com/asdf-vm/asdf/blob/0adc6c11fb4f87dbb476f8b61e4cf8fb7613599b/lib/utils.bash#L571-L575