### PR TITLE
use env_path instead of env.PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,20 +640,18 @@ These can be simple key/value entries like this:
 NODE_ENV = 'production'
 ```
 
-`PATH` is treated specially, it needs to be defined as an array with `$PATH` at the end:
+`PATH` is treated specially, it needs to be defined as an array in `env_path`:
 
 ```toml
-[env]
-PATH = [
+env_path = [
     # adds an absolute path
     "~/.local/share/bin",
     # adds a path relative to the .rtx.toml, not PWD
     "./node_modules/.bin",
-    "$PATH"
 ]
 ```
 
-_Note: other PATH-like variables like `LD_LIBRARY_PATH` cannot be set this way._
+_Note: `env_path` is a top-level key, it does not go inside of `[env]`._
 
 Environment variable values can be templates, see [Templates](#templates) for details.
 

--- a/e2e/.e2e.rtx.toml
+++ b/e2e/.e2e.rtx.toml
@@ -1,7 +1,7 @@
 dotenv = '.test-env'
+env_path = ["/root", "./cwd"]
 [env]
 FOO = "bar"
-PATH = ["/root", "./cwd", "$PATH"]
 
 [tools]
 tiny = "latest"

--- a/e2e/cd/test_fish
+++ b/e2e/cd/test_fish
@@ -1,5 +1,7 @@
 #!/usr/bin/env fish
 # shellcheck disable=SC1072,SC1065,SC1064,SC1073,SC2103
+
+set -gx PATH $ROOT/target/debug:$PATH
 set -l orig_node (node -v)
 
 #set -l fish_trace 1

--- a/e2e/test_local
+++ b/e2e/test_local
@@ -21,9 +21,9 @@ export RTX_MISSING_RUNTIME_BEHAVIOR=autoinstall
 assert_raises "rtx uninstall shfmt@3.6.0"
 
 assert "rtx local" "dotenv = '.test-env'
+env_path = [\"/root\", \"./cwd\"]
 [env]
 FOO = \"bar\"
-PATH = [\"/root\", \"./cwd\", \"\$PATH\"]
 
 [tools]
 tiny = \"latest\"
@@ -31,9 +31,9 @@ tiny = \"latest\"
 "
 
 assert "rtx local shfmt@3.5.0" "dotenv = '.test-env'
+env_path = [\"/root\", \"./cwd\"]
 [env]
 FOO = \"bar\"
-PATH = [\"/root\", \"./cwd\", \"\$PATH\"]
 
 [tools]
 tiny = \"latest\"
@@ -50,9 +50,9 @@ assert_raises "rtx uninstall shfmt@3.6.0"
 assert_raises "rtx local shfmt --install-missing"
 
 assert "rtx local shfmt@3.6.0" "dotenv = '.test-env'
+env_path = [\"/root\", \"./cwd\"]
 [env]
 FOO = \"bar\"
-PATH = [\"/root\", \"./cwd\", \"\$PATH\"]
 
 [tools]
 tiny = \"latest\"
@@ -66,9 +66,9 @@ if [[ "$(rtx exec -- shfmt --version)" != "v3.6.0" ]]; then
 fi
 
 assert "rtx local --rm shfmt" "dotenv = '.test-env'
+env_path = [\"/root\", \"./cwd\"]
 [env]
 FOO = \"bar\"
-PATH = [\"/root\", \"./cwd\", \"\$PATH\"]
 
 [tools]
 tiny = \"latest\"

--- a/schema/rtx.json
+++ b/schema/rtx.json
@@ -10,6 +10,14 @@
       "description": "path to .env file",
       "type": "string"
     },
+    "env_path": {
+      "description": "PATH entries to add",
+      "type": "array",
+      "items": {
+        "description": "a path to add to PATH",
+        "type": "string"
+      }
+    },
     "env": {
       "description": "environment variables",
       "type": "object",

--- a/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__path_dirs-3.snap
+++ b/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__path_dirs-3.snap
@@ -2,7 +2,7 @@
 source: src/config/config_file/rtx_toml.rs
 expression: cf
 ---
+env_path=["/foo", "./bar"]
 [env]
 foo="bar"
-PATH=["/foo", "./bar", "$PATH"]
 


### PR DESCRIPTION
I think this style is cleaner and does not imply that
it can be used for LD_LIBRARY_PATH or similar env vars

This is a breaking change for .rtx.toml PATH functionality,
but it is marked as experimental so we can change it with
a minor release
