### PR TITLE
use `env_file` instead of `dotenv` in .rtx.toml

### DIFF
--- a/.rtx.toml
+++ b/.rtx.toml
@@ -1,5 +1,5 @@
 #:schema ./schema/rtx.json
-dotenv = '.env'
+env_file = '.env'
 [env]
 FOO = "bar"
 THIS_PROJECT = "{{config_root}}-{{env.PWD}}"

--- a/README.md
+++ b/README.md
@@ -686,13 +686,13 @@ Environment variable values can be templates, see [Templates](#templates) for de
 LD_LIBRARY_PATH = "/some/path:{{env.LD_LIBRARY_PATH}}"
 ```
 
-`dotenv` can be used to specify a [dotenv](https://dotenv.org) file to load:
+`env_file` can be used to specify a [dotenv](https://dotenv.org) file to load:
 
 ```toml
-dotenv = '.env'
+env_file = '.env'
 ```
 
-_Note: `dotenv` goes at the top of the file, above `[env]`._
+_Note: `env_file` goes at the top of the file, above `[env]`._
 
 ### Environment variables
 

--- a/e2e/.e2e.rtx.toml
+++ b/e2e/.e2e.rtx.toml
@@ -1,4 +1,4 @@
-dotenv = '.test-env'
+env_file = '.test-env'
 env_path = ["/root", "./cwd"]
 [env]
 FOO = "bar"

--- a/e2e/config/.e2e.rtx.toml
+++ b/e2e/config/.e2e.rtx.toml
@@ -1,4 +1,4 @@
-dotenv = '.test-env'
+env_file = '.test-env'
 env_path = ["/root", "./cwd"]
 [env]
 FOO = "bar"

--- a/e2e/test_local
+++ b/e2e/test_local
@@ -20,7 +20,7 @@ export RTX_MISSING_RUNTIME_BEHAVIOR=autoinstall
 
 assert_raises "rtx uninstall shfmt@3.6.0"
 
-assert "rtx local" "dotenv = '.test-env'
+assert "rtx local" "env_file = '.test-env'
 env_path = [\"/root\", \"./cwd\"]
 [env]
 FOO = \"bar\"
@@ -31,7 +31,7 @@ tiny = \"latest\"
 "
 
 rtx local shfmt@3.5.0
-assert "rtx local" "dotenv = '.test-env'
+assert "rtx local" "env_file = '.test-env'
 env_path = [\"/root\", \"./cwd\"]
 [env]
 FOO = \"bar\"
@@ -51,7 +51,7 @@ assert_raises "rtx uninstall shfmt@3.6.0"
 assert_raises "rtx local shfmt --install-missing"
 
 rtx local shfmt@3.6.0
-assert "rtx local" "dotenv = '.test-env'
+assert "rtx local" "env_file = '.test-env'
 env_path = [\"/root\", \"./cwd\"]
 [env]
 FOO = \"bar\"
@@ -68,7 +68,7 @@ if [[ "$(rtx exec -- shfmt --version)" != "v3.6.0" ]]; then
 fi
 
 rtx local --rm shfmt
-assert "rtx local" "dotenv = '.test-env'
+assert "rtx local" "env_file = '.test-env'
 env_path = [\"/root\", \"./cwd\"]
 [env]
 FOO = \"bar\"

--- a/schema/rtx.json
+++ b/schema/rtx.json
@@ -6,7 +6,7 @@
   "type": "object",
   "additionalProperties": false,
   "properties": {
-    "dotenv": {
+    "env_file": {
       "description": "path to .env file",
       "type": "string"
     },

--- a/src/config/config_file/rtx_toml.rs
+++ b/src/config/config_file/rtx_toml.rs
@@ -27,7 +27,7 @@ pub struct RtxToml {
     context: Context,
     path: PathBuf,
     toolset: Toolset,
-    dotenv: Option<PathBuf>,
+    env_file: Option<PathBuf>,
     env: HashMap<String, String>,
     path_dirs: Vec<PathBuf>,
     settings: SettingsBuilder,
@@ -75,7 +75,8 @@ impl RtxToml {
         let doc: Document = s.parse().suggestion("ensure file is valid TOML")?;
         for (k, v) in doc.iter() {
             match k {
-                "dotenv" => self.parse_dotenv(k, v)?,
+                "dotenv" => self.parse_env_file(k, v)?,
+                "env_file" => self.parse_env_file(k, v)?,
                 "env_path" => self.path_dirs = self.parse_path_env(k, v)?,
                 "env" => self.parse_env(k, v)?,
                 "alias" => self.alias = self.parse_alias(k, v)?,
@@ -93,7 +94,7 @@ impl RtxToml {
         self.settings.clone()
     }
 
-    fn parse_dotenv(&mut self, k: &str, v: &Item) -> Result<()> {
+    fn parse_env_file(&mut self, k: &str, v: &Item) -> Result<()> {
         self.trust_check()?;
         match v.as_str() {
             Some(filename) => {
@@ -102,7 +103,7 @@ impl RtxToml {
                     let (k, v) = item?;
                     self.env.insert(k, v);
                 }
-                self.dotenv = Some(path);
+                self.env_file = Some(path);
             }
             _ => parse_error!(k, v, "string")?,
         }
@@ -691,8 +692,8 @@ impl ConfigFile for RtxToml {
     }
 
     fn watch_files(&self) -> Vec<PathBuf> {
-        match &self.dotenv {
-            Some(dotenv) => vec![self.path.clone(), dotenv.clone()],
+        match &self.env_file {
+            Some(env_file) => vec![self.path.clone(), env_file.clone()],
             None => vec![self.path.clone()],
         }
     }


### PR DESCRIPTION
This matches the other config. `dotenv` is still going to be supported for the forseeable future to not break anything, but will probably go away eventually.
