### PR TITLE
bug: fix bug with runtime symlinks

### DIFF
--- a/src/tool.rs
+++ b/src/tool.rs
@@ -170,7 +170,11 @@ impl Tool {
     pub fn is_version_installed(&self, tv: &ToolVersion) -> bool {
         match tv.request {
             ToolVersionRequest::System(_) => true,
-            _ => tv.install_path().exists() && !self.incomplete_file_path(tv).exists(),
+            _ => {
+                tv.install_path().exists()
+                    && !self.incomplete_file_path(tv).exists()
+                    && !is_runtime_symlink(&tv.install_path())
+            }
         }
     }
 


### PR DESCRIPTION
if there was a symlink for a version like go1.20.3 for go1.20,
it was preventing you from installing go1.20 explicitly.
