### PR TITLE
improve error message on missing env_file

### DIFF
--- a/src/config/config_file/rtx_toml.rs
+++ b/src/config/config_file/rtx_toml.rs
@@ -101,7 +101,15 @@ impl RtxToml {
         match v.as_str() {
             Some(filename) => {
                 let path = self.path.parent().unwrap().join(filename);
-                for item in dotenvy::from_path_iter(&path)? {
+                let dotenv = match dotenvy::from_path_iter(&path) {
+                    Ok(dotenv) => dotenv,
+                    Err(e) => Err(eyre!(
+                        "failed to parse dotenv file: {}\n{:#}",
+                        path.display(),
+                        e
+                    ))?,
+                };
+                for item in dotenv {
                     let (k, v) = item?;
                     self.env.insert(k, v);
                 }

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -420,7 +420,7 @@ fn load_all_config_files(
             // need to parse this config file
             None => match parse_config_file(&f, settings, legacy_filenames, tools) {
                 Ok(cf) => Ok((f, cf)),
-                Err(err) => Err(eyre!("error parsing: {} {:#}", f.display(), err)),
+                Err(err) => Err(eyre!("error reading config: {}\n{:#}", f.display(), err)),
             },
         })
         .collect::<Vec<Result<_>>>()


### PR DESCRIPTION
This could probably be better still, but it is an improvement.

Fixes #472
