### PR TITLE
Correct nix example to point to correct repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,7 +400,7 @@ For NixOS or those using the Nix package manager:
     nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     rtx-flake = {
-      url = "github:chadac/rtx/add-nix-flake";
+      url = "github:jdxcode/rtx";
       inputs.nixpkgs.follows = "nixpkgs";
       inputs.flake-utils.follows = "flake-utils";
     };


### PR DESCRIPTION
The example nix snippet points to a fork, now that fork is merged it should point to this repo. I found this error because the provided snippet didn't build for me (nix on macos), but updating it like this PR fixed it.