### PR TITLE
unhiding current command

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@ v20.0.0
   - [`rtx bin-paths`](#rtx-bin-paths)
   - [`rtx cache clear`](#rtx-cache-clear)
   - [`rtx completion [SHELL]`](#rtx-completion-shell)
+  - [`rtx current [PLUGIN]`](#rtx-current-plugin)
   - [`rtx deactivate`](#rtx-deactivate)
   - [`rtx direnv activate`](#rtx-direnv-activate)
   - [`rtx doctor`](#rtx-doctor)
@@ -1599,6 +1600,35 @@ Examples:
   $ rtx completion bash > /etc/bash_completion.d/rtx
   $ rtx completion zsh  > /usr/local/share/zsh/site-functions/_rtx
   $ rtx completion fish > ~/.config/fish/completions/rtx.fish
+```
+### `rtx current [PLUGIN]`
+
+```
+Shows current active and installed runtime versions
+
+This is similar to `rtx ls --current`, but this only shows the runtime
+and/or version. It's designed to fit into scripts more easily.
+
+Usage: current [PLUGIN]
+
+Arguments:
+  [PLUGIN]
+          Plugin to show versions of e.g.: ruby, nodejs
+
+Examples:
+  # outputs `.tool-versions` compatible format
+  $ rtx current
+  python 3.11.0 3.10.0
+  shfmt 3.6.0
+  shellcheck 0.9.0
+  nodejs 20.0.0
+
+  $ rtx current nodejs
+  20.0.0
+
+  # can output multiple versions
+  $ rtx current python
+  3.11.0 3.10.0
 ```
 ### `rtx deactivate`
 

--- a/man/man1/rtx.1
+++ b/man/man1/rtx.1
@@ -55,6 +55,9 @@ Manage the rtx cache
 rtx\-completion(1)
 Generate shell completions
 .TP
+rtx\-current(1)
+Shows current active and installed runtime versions
+.TP
 rtx\-deactivate(1)
 Disable rtx for current shell session
 .TP

--- a/src/cli/current.rs
+++ b/src/cli/current.rs
@@ -11,12 +11,8 @@ use crate::toolset::{Toolset, ToolsetBuilder};
 ///
 /// This is similar to `rtx ls --current`, but this only shows the runtime
 /// and/or version. It's designed to fit into scripts more easily.
-///
-/// This command is currently hidden as we may be able to merge it with `ls`
-/// and it's confusing to have two commands that do similar things.
-/// It will probably never be removed in order to retain some compatibility with asdf.
 #[derive(Debug, clap::Args)]
-#[clap(verbatim_doc_comment, hide = true, after_long_help = AFTER_LONG_HELP)]
+#[clap(verbatim_doc_comment, after_long_help = AFTER_LONG_HELP)]
 pub struct Current {
     /// Plugin to show versions of
     /// e.g.: ruby, nodejs


### PR DESCRIPTION
I feel this has some utility even with the changes to `rtx ls`. Without this, there is not an easy command to just get the current version of a plugin with nothing else
