### PR TITLE
ci: Add AUR rtx-bin package

### DIFF
--- a/.github/workflows/rtx.yml
+++ b/.github/workflows/rtx.yml
@@ -272,6 +272,9 @@ jobs:
       - name: Release to aur
         run: scripts/release-aur.sh
         working-directory: rtx
+      - name: Release aur-bin
+        run: scripts/release-aur-bin.sh
+        working-directory: rtx
   bump-homebrew-formula:
     runs-on: macos-latest
     if: startsWith(github.event.ref, 'refs/tags/v')

--- a/scripts/release-aur-bin.sh
+++ b/scripts/release-aur-bin.sh
@@ -5,15 +5,15 @@ RTX_VERSION=$(./scripts/get-version.sh)
 
 SHA512=$(curl -L "https://github.com/jdxcode/rtx/archive/$RTX_VERSION.tar.gz" | sha512sum | awk '{print $1}')
 
-if [ ! -d aur ]; then
-	git clone ssh://aur@aur.archlinux.org/rtx.git aur
+if [ ! -d aur-bin ]; then
+	git clone ssh://aur@aur.archlinux.org/rtx-bin.git aur-bin
 fi
-git -C aur pull
+git -C aur-bin pull
 
 cat >aur/PKGBUILD <<EOF
 # Maintainer: Jeff Dickey <releases at rtx dot pub>
 
-pkgname=rtx
+pkgname=rtx-bin
 pkgver=${RTX_VERSION#v*}
 pkgrel=1
 pkgdesc='Polyglot runtime manager'
@@ -22,31 +22,23 @@ url='https://github.com/jdxcode/rtx'
 license=('MIT')
 makedepends=('cargo')
 provides=('rtx')
-conflicts=('rtx-bin')
+conflicts=('rtx')
 options=('!lto')
 source=("\$pkgname-\$pkgver.tar.gz::https://github.com/jdxcode/\$pkgname/archive/v\$pkgver.tar.gz")
 sha512sums=('$SHA512')
 
 prepare() {
-    cd "\$srcdir/\$pkgname-\$pkgver"
-    cargo fetch --locked --target "\$CARCH-unknown-linux-gnu"
-}
-
-build() {
-    cd "\$srcdir/\$pkgname-\$pkgver"
-    export RUSTUP_TOOLCHAIN=stable
-    export CARGO_TARGET_DIR=target
-    cargo build --frozen --release
+    tar -xzf rtx-v\$pkgver-linux-x64.tar.gz
 }
 
 package() {
-    cd "\$srcdir/\$pkgname-\$pkgver"
-    install -Dm0755 -t "\$pkgdir/usr/bin/" "target/release/\$pkgname"
+    cd "\$srcdir/"
+    install -Dm755 rtx/bin/rtx "\$pkgdir/usr/bin/rtx"
+    install -Dm644 rtx/man/man1/rtx.1 "\$pkgdir/usr/share/man/man1/rtx.1"
 }
 
 check() {
-    cd "\$srcdir/\$pkgname-\$pkgver"
-    ./target/release/rtx --version
+    "\$srcdir/rtx/bin/rtx" --version
 }
 EOF
 
@@ -58,16 +50,15 @@ pkgbase = rtx
 	url = https://github.com/jdxcode/rtx
 	arch = x86_64
 	license = MIT
-	makedepends = cargo
 	provides = rtx
 	conflicts = rtx
 	source = rtx-${RTX_VERSION#v*}.tar.gz::https://github.com/jdxcode/rtx/archive/$RTX_VERSION.tar.gz
 	sha512sums = $SHA512
 
-pkgname = rtx
+pkgname = rtx-bin
 EOF
 
-cd aur
+cd aur-bin
 git add .SRCINFO PKGBUILD
 git commit -m "rtx ${RTX_VERSION#v}"
 git push


### PR DESCRIPTION
See https://github.com/jdxcode/rtx/discussions/440

This won't run until ownership of the [rtx-bin AUR package](https://aur.archlinux.org/packages/rtx-bin) has been changed to jdxcode

TODO:
  * Would be good to refactor the code shared with the original `rtx` package scripts.