### PR TITLE
ci: Fix AUR rtx-bin .SRCINFO pkgbase

### DIFF
--- a/scripts/release-aur-bin.sh
+++ b/scripts/release-aur-bin.sh
@@ -20,7 +20,6 @@ pkgdesc='Polyglot runtime manager'
 arch=('x86_64')
 url='https://github.com/jdxcode/rtx'
 license=('MIT')
-makedepends=('cargo')
 provides=('rtx')
 conflicts=('rtx')
 options=('!lto')
@@ -43,7 +42,7 @@ check() {
 EOF
 
 cat >aur-bin/.SRCINFO <<EOF
-pkgbase = rtx
+pkgbase = rtx-bin
 	pkgdesc = Polyglot runtime manager
 	pkgver = ${RTX_VERSION#v*}
 	pkgrel = 1


### PR DESCRIPTION
Fixing an error after the first ever attempt at automated release: https://github.com/jdxcode/rtx/actions/runs/4902977788/jobs/8755243840

Error was:

```
+ git push
remote: error: invalid pkgbase: rtx, expected rtx-bin
remote: error: hook declined to update refs/heads/master
```