### PR TITLE
added "about" help to external commands

### DIFF
--- a/docs/node.md
+++ b/docs/node.md
@@ -62,7 +62,7 @@ rtx uses a `.tool-versions` or `.rtx.toml` file for auto-switching between softw
 We provide a command for running the installed `node-build` command:
 
 ```bash
-rtx node nodebuild --version
+rtx node node-build --version
 ```
 
 ### node-build advanced variations
@@ -75,7 +75,7 @@ Some of them will work out of the box, and some will need a bit of investigation
 To list all the available variations run:
 
 ```bash
-rtx node nodebuild --definitions
+rtx node node-build --definitions
 ```
 
 _Note that this command only lists the current `node-build` definitions. You might want to [update the local `node-build` repository](#updating-node-build-definitions) before listing them._

--- a/e2e/test_nodejs
+++ b/e2e/test_nodejs
@@ -9,4 +9,11 @@ rtx plugin uninstall node
 rtx i node node@lts/hydrogen
 assert_contains "rtx x node@lts/hydrogen -- node --version" "v18."
 assert "rtx x -- node --version" "v20.0.0"
-assert_contains "rtx node nodebuild --version" "node-build "
+assert_contains "rtx node node-build --version" "node-build "
+
+# test rtx-nodejs
+rtx plugin i nodejs
+rtx use nodejs@20.1.0
+assert "rtx x -- node --version" "v20.1.0"
+assert_contains "rtx nodejs nodebuild --version" "node-build "
+rtx plugin uninstall nodejs

--- a/src/plugins/mod.rs
+++ b/src/plugins/mod.rs
@@ -1,3 +1,4 @@
+use clap::Command;
 use std::collections::{BTreeMap, HashMap};
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
@@ -54,10 +55,15 @@ pub trait Plugin: Debug + Send + Sync {
         let contents = std::fs::read_to_string(path)?;
         Ok(contents.trim().to_string())
     }
-    fn external_commands(&self) -> Result<Vec<Vec<String>>> {
+    fn external_commands(&self) -> Result<Vec<Command>> {
         Ok(vec![])
     }
-    fn execute_external_command(&self, _command: &str, _args: Vec<String>) -> Result<()> {
+    fn execute_external_command(
+        &self,
+        _config: &Config,
+        _command: &str,
+        _args: Vec<String>,
+    ) -> Result<()> {
         unimplemented!()
     }
     fn install_version(&self, config: &Config, tv: &ToolVersion, pr: &ProgressReport)

--- a/src/plugins/script_manager.rs
+++ b/src/plugins/script_manager.rs
@@ -45,6 +45,7 @@ pub enum Script {
     ExecEnv,
     Install,
     ListBinPaths,
+    RunExternalCommand(PathBuf, Vec<String>),
     Uninstall,
 }
 
@@ -62,6 +63,7 @@ impl Display for Script {
             Script::Install => write!(f, "install"),
             Script::Uninstall => write!(f, "uninstall"),
             Script::ListBinPaths => write!(f, "list-bin-paths"),
+            Script::RunExternalCommand(_, _) => write!(f, "run-external-command"),
             Script::ExecEnv => write!(f, "exec-env"),
             Script::Download => write!(f, "download"),
         }
@@ -108,7 +110,10 @@ impl ScriptManager {
     }
 
     pub fn get_script_path(&self, script: &Script) -> PathBuf {
-        self.plugin_path.join("bin").join(script.to_string())
+        match script {
+            Script::RunExternalCommand(path, _) => path.clone(),
+            _ => self.plugin_path.join("bin").join(script.to_string()),
+        }
     }
 
     pub fn script_exists(&self, script: &Script) -> bool {
@@ -118,6 +123,7 @@ impl ScriptManager {
     pub fn cmd(&self, settings: &Settings, script: &Script) -> Expression {
         let args = match script {
             Script::ParseLegacyFile(filename) => vec![filename.clone()],
+            Script::RunExternalCommand(_, args) => args.clone(),
             _ => vec![],
         };
         let script_path = self.get_script_path(script);

--- a/src/tool.rs
+++ b/src/tool.rs
@@ -2,6 +2,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::fs::{remove_file, File};
 use std::path::{Path, PathBuf};
 
+use clap::Command;
 use color_eyre::eyre::{eyre, Result};
 use console::style;
 use itertools::Itertools;
@@ -254,11 +255,16 @@ impl Tool {
         self.plugin.uninstall(pr)
     }
 
-    pub fn external_commands(&self) -> Result<Vec<Vec<String>>> {
+    pub fn external_commands(&self) -> Result<Vec<Command>> {
         self.plugin.external_commands()
     }
-    pub fn execute_external_command(&self, command: &str, args: Vec<String>) -> Result<()> {
-        self.plugin.execute_external_command(command, args)
+    pub fn execute_external_command(
+        &self,
+        config: &Config,
+        command: &str,
+        args: Vec<String>,
+    ) -> Result<()> {
+        self.plugin.execute_external_command(config, command, args)
     }
     pub fn parse_legacy_file(&self, path: &Path, settings: &Settings) -> Result<String> {
         self.plugin.parse_legacy_file(path, settings)


### PR DESCRIPTION
This should make it more clear what the topics/commands are.
I also renamed nodebuild -> node-build in the core plugin which hopefully will not be too big of a problem.

Fixes #551