### PR TITLE
`rtx use` should use .tool-versions if it exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -2318,7 +2318,7 @@ Options:
           Use the global config file (~/.config/rtx/config.toml) instead of the local one
 
   -p, --path <PATH>
-          Specify a path to a config file
+          Specify a path to a config file or directory
 
 Examples:
   # set the current version of node to 20.x in .rtx.toml of current directory

--- a/completions/_rtx
+++ b/completions/_rtx
@@ -1379,8 +1379,8 @@ If not specified, all current tools will be upgraded:' \
 (use)
 _arguments "${_arguments_options[@]}" \
 '*--remove=[Remove the tool(s) from config file]:TOOL: ' \
-'-p+[Specify a path to a config file]:PATH:_files' \
-'--path=[Specify a path to a config file]:PATH:_files' \
+'-p+[Specify a path to a config file or directory]:PATH:_files' \
+'--path=[Specify a path to a config file or directory]:PATH:_files' \
 '-j+[Number of plugins and runtimes to install in parallel
 default\: 4]: : ' \
 '--jobs=[Number of plugins and runtimes to install in parallel

--- a/completions/rtx.fish
+++ b/completions/rtx.fish
@@ -635,7 +635,7 @@ complete -c rtx -n "__fish_seen_subcommand_from upgrade" -l trace -d 'Sets log l
 complete -c rtx -n "__fish_seen_subcommand_from upgrade" -s v -l verbose -d 'Show installation output'
 complete -c rtx -n "__fish_seen_subcommand_from upgrade" -s h -l help -d 'Print help'
 complete -c rtx -n "__fish_seen_subcommand_from use" -l remove -d 'Remove the tool(s) from config file' -r
-complete -c rtx -n "__fish_seen_subcommand_from use" -s p -l path -d 'Specify a path to a config file' -r -F
+complete -c rtx -n "__fish_seen_subcommand_from use" -s p -l path -d 'Specify a path to a config file or directory' -r -F
 complete -c rtx -n "__fish_seen_subcommand_from use" -s j -l jobs -d 'Number of plugins and runtimes to install in parallel
 default: 4' -r
 complete -c rtx -n "__fish_seen_subcommand_from use" -l log-level -d 'Set the log output verbosity' -r

--- a/src/cli/snapshots/rtx__cli__r#use__tests__use_local_tool_versions.snap
+++ b/src/cli/snapshots/rtx__cli__r#use__tests__use_local_tool_versions.snap
@@ -1,0 +1,6 @@
+---
+source: src/cli/use.rs
+expression: "fs::read_to_string(&cf_path).unwrap()"
+---
+tiny 3
+

--- a/src/config/config_file/mod.rs
+++ b/src/config/config_file/mod.rs
@@ -132,15 +132,11 @@ impl dyn ConfigFile {
 }
 
 pub fn init(path: &Path, is_trusted: bool) -> Box<dyn ConfigFile> {
-    if path.ends_with(env::RTX_DEFAULT_CONFIG_FILENAME.as_str())
-        || path.extension() == Some("toml".as_ref())
-    {
-        return Box::new(RtxToml::init(path, is_trusted));
-    } else if path.ends_with(env::RTX_DEFAULT_TOOL_VERSIONS_FILENAME.as_str()) {
-        return Box::new(ToolVersions::init(path, is_trusted));
+    match detect_config_file_type(path) {
+        Some(ConfigFileType::RtxToml) => Box::new(RtxToml::init(path, is_trusted)),
+        Some(ConfigFileType::ToolVersions) => Box::new(ToolVersions::init(path, is_trusted)),
+        _ => panic!("Unknown config file type: {}", path.display()),
     }
-
-    panic!("Unknown config file type: {}", path.display());
 }
 
 pub fn parse(path: &Path, is_trusted: bool) -> Result<Box<dyn ConfigFile>> {


### PR DESCRIPTION
Fixes #526
