### PR TITLE
Use nushell syntax highlighting in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -430,7 +430,7 @@ echo 'rtx activate fish | source' >> ~/.config/fish/config.fish
 
 ```nushell
 do {
-  let rtxpath = $"($nu.config-path | path dirname | path join "rtx.nu")"
+  let rtxpath = ($nu.config-path | path dirname | path join "rtx.nu")
   run-external rtx activate nu --redirect-stdout | save $rtxpath -f
   $"\nsource "($rtxpath)"" | save $nu.config-path --append
 }

--- a/README.md
+++ b/README.md
@@ -430,8 +430,8 @@ echo 'rtx activate fish | source' >> ~/.config/fish/config.fish
 
 ```nushell
 do {
-  let rtxpath = $"($nu.config-path | path dirname | path join "rtx.nu")";
-  run-external rtx activate nu --redirect-stdout | save $rtxpath -f;
+  let rtxpath = $"($nu.config-path | path dirname | path join "rtx.nu")"
+  run-external rtx activate nu --redirect-stdout | save $rtxpath -f
   $"\nsource "($rtxpath)"" | save $nu.config-path --append
 }
 ```

--- a/README.md
+++ b/README.md
@@ -428,7 +428,7 @@ echo 'rtx activate fish | source' >> ~/.config/fish/config.fish
 
 #### Nushell
 
-```sh-session
+```nushell
 do {
   let rtxpath = $"($nu.config-path | path dirname | path join "rtx.nu")";
   run-external rtx activate nu --redirect-stdout | save $rtxpath -f;


### PR DESCRIPTION
GitHub now has it.

> ```console
> do {
>   let rtxpath = $"($nu.config-path | path dirname | path join "rtx.nu")";
>   run-external rtx activate nu --redirect-stdout | save $rtxpath -f;
>   $"\nsource "($rtxpath)"" | save $nu.config-path --append
> }
> ```

becomes

> ```nushell
> do {
>   let rtxpath = ($nu.config-path | path dirname | path join "rtx.nu")
>   run-external rtx activate nu --redirect-stdout | save $rtxpath -f
>   $"\nsource "($rtxpath)"" | save $nu.config-path --append
> }
> ```