### PR TITLE
build alpine with edge release

### DIFF
--- a/packaging/alpine/Dockerfile
+++ b/packaging/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3
+FROM alpine:edge
 RUN apk add --no-cache sudo build-base alpine-sdk bash direnv glab atools
 RUN apk fix
 RUN adduser -D packager


### PR DESCRIPTION
- add plugin name to legacy file cache
- build alpine with edge
