### PR TITLE
allow disabling tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -673,7 +673,8 @@ python = ['3.10', '3.11']
 [settings]
 # plugins can read the versions files used by other version managers (if enabled by the plugin)
 # for example, .nvmrc in the case of node's nvm
-legacy_version_file = true         # enabled by default (different than asdf)
+legacy_version_file = true                     # enabled by default (unlike asdf)
+legacy_version_file_disable_tools = ['python'] # disable for specific tools
 
 # configure `rtx install` to always keep the downloaded archive
 always_keep_download = false        # deleted after install by default
@@ -696,6 +697,7 @@ raw = false         # set to true to directly pipe plugins to stdin/stdout/stder
 
 shorthands_file = '~/.config/rtx/shorthands.toml' # path to the shorthands file, see `RTX_SHORTHANDS_FILE`
 disable_default_shorthands = false # disable the default shorthands, see `RTX_DISABLE_DEFAULT_SHORTHANDS`
+disable_tools = ['node']           # disable specific tools, generally used to turn off core tools
 
 experimental = false # enable experimental features
 log_level = 'debug' # log verbosity, see `RTX_LOG_LEVEL`
@@ -748,13 +750,19 @@ to use this feature.
 Set the version for a runtime. For example, `RTX_NODE_VERSION=20` will use node@20.x regardless
 of what is set in `.tool-versions`/`.rtx.toml`.
 
-#### `RTX_LEGACY_VERSION_FILE`
+#### `RTX_LEGACY_VERSION_FILE=1`
 
 Plugins can read the versions files used by other version managers (if enabled by the plugin)
 for example, `.nvmrc` in the case of node's nvm. See [legacy version files](#legacy-version-files) for more
 information.
 
-#### `RTX_USE_TOML`
+Set to "0" to disable legacy version file parsing.
+
+#### `RTX_LEGACY_VERSION_FILE_DISABLE_TOOLS=nodejs,python`
+
+Disable legacy version file parsing for specific tools. Separate with `,`.
+
+#### `RTX_USE_TOML=0`
 
 Set to `1` to default to using `.rtx.toml` in `rtx local` instead of `.tool-versions` for
 configuration. This will be default behavior once we hit the [Calver](#versioning) release.
@@ -829,6 +837,11 @@ node = "https://github.com/my-org/rtx-node.git"
 
 Disables the shorthand aliases for installing plugins. You will have to specify full urls when
 installing plugins, e.g.: `rtx plugin install node https://github.com/asdf-vm/asdf-node.git`
+
+#### `RTX_DISABLE_TOOLS=python,nodejs`
+
+Disables the specified tools. Separate with `,`. Generally used for core plugins but works with
+all.
 
 #### `RTX_HIDE_UPDATE_WARNING=1`
 

--- a/e2e/assert.sh
+++ b/e2e/assert.sh
@@ -16,6 +16,15 @@ assert_contains() {
   fi
 }
 
+assert_not_contains() {
+	local actual
+	actual="$(bash -c "$1")"
+	if [[ "$actual" == *"$2"* ]]; then
+		echo "Expected '$2' to not be in '$actual'"
+		exit 1
+	fi
+}
+
 assert_fail() {
   if bash -c "$1" 2>&1; then
     echo "Expected failure but succeeded"

--- a/e2e/test_nodejs
+++ b/e2e/test_nodejs
@@ -17,3 +17,10 @@ rtx use nodejs@20.1.0
 assert "rtx x -- node --version" "v20.1.0"
 assert_contains "rtx nodejs nodebuild --version" "node-build "
 rtx plugin uninstall nodejs
+
+# RTX_LEGACY_VERSION_FILE env var
+RTX_LEGACY_VERSION_FILE=1 assert_contains "rtx current node" "20.0.0"
+RTX_LEGACY_VERSION_FILE=0 assert_not_contains "rtx current node" "20.0.0"
+
+# disable nodejs plugin
+RTX_DISABLE_TOOLS=node assert_not_contains "rtx plugins --core" "node"

--- a/schema/rtx.json
+++ b/schema/rtx.json
@@ -114,6 +114,14 @@
           "description": "should rtx parse legacy version files (e.g. .node-version)",
           "type": "boolean"
         },
+        "legacy_version_file_disable_tools": {
+          "description": "tools that should not have their legacy version files parsed",
+          "type": "array",
+          "items": {
+              "description": "tool name",
+              "type": "string"
+          }
+        },
         "always_keep_download": {
           "description": "should rtx keep downloaded files after installation",
           "type": "boolean"
@@ -153,6 +161,14 @@
         "disable_default_shorthands": {
           "description": "disables built-in shorthands",
           "type": "boolean"
+        },
+        "disable_tools": {
+          "description": "tools that should not be used",
+          "type": "array",
+          "items": {
+            "description": "tool name",
+            "type": "string"
+          }
         },
         "trusted_config_paths": {
           "description": "config files with these prefixes will be trusted by default",

--- a/src/cli/settings/snapshots/rtx__cli__settings__ls__tests__settings_ls.snap
+++ b/src/cli/settings/snapshots/rtx__cli__settings__ls__tests__settings_ls.snap
@@ -2,16 +2,19 @@
 source: src/cli/settings/ls.rs
 expression: stdout
 ---
-experimental = true
-missing_runtime_behavior = autoinstall
 always_keep_download = true
 always_keep_install = true
+asdf_compat = false
+disable_default_shorthands = false
+disable_tools = []
+experimental = true
+jobs = 2
 legacy_version_file = true
+legacy_version_file_disable_tools = []
+log_level = INFO
+missing_runtime_behavior = autoinstall
 plugin_autoupdate_last_check_duration = 20
+raw = false
 trusted_config_paths = []
 verbose = true
-asdf_compat = false
-jobs = 2
-disable_default_shorthands = false
-log_level = INFO
-raw = false
+

--- a/src/cli/settings/snapshots/rtx__cli__settings__set__tests__settings_set.snap
+++ b/src/cli/settings/snapshots/rtx__cli__settings__set__tests__settings_set.snap
@@ -2,16 +2,19 @@
 source: src/cli/settings/set.rs
 expression: stdout
 ---
-experimental = true
-missing_runtime_behavior = autoinstall
 always_keep_download = true
 always_keep_install = true
+asdf_compat = false
+disable_default_shorthands = false
+disable_tools = []
+experimental = true
+jobs = 2
 legacy_version_file = false
+legacy_version_file_disable_tools = []
+log_level = INFO
+missing_runtime_behavior = autoinstall
 plugin_autoupdate_last_check_duration = 1
+raw = false
 trusted_config_paths = []
 verbose = true
-asdf_compat = false
-jobs = 2
-disable_default_shorthands = false
-log_level = INFO
-raw = false
+

--- a/src/cli/settings/unset.rs
+++ b/src/cli/settings/unset.rs
@@ -43,19 +43,21 @@ mod tests {
 
         let stdout = assert_cli!("settings");
         assert_snapshot!(stdout, @r###"
-        experimental = true
-        missing_runtime_behavior = autoinstall
         always_keep_download = true
         always_keep_install = true
+        asdf_compat = false
+        disable_default_shorthands = false
+        disable_tools = []
+        experimental = true
+        jobs = 2
         legacy_version_file = true
+        legacy_version_file_disable_tools = []
+        log_level = INFO
+        missing_runtime_behavior = autoinstall
         plugin_autoupdate_last_check_duration = 20
+        raw = false
         trusted_config_paths = []
         verbose = true
-        asdf_compat = false
-        jobs = 2
-        disable_default_shorthands = false
-        log_level = INFO
-        raw = false
         "###);
 
         reset_config();

--- a/src/config/config_file/rtx_toml.rs
+++ b/src/config/config_file/rtx_toml.rs
@@ -390,6 +390,10 @@ impl RtxToml {
                         "legacy_version_file" => {
                             settings.legacy_version_file = Some(self.parse_bool(&k, v)?)
                         }
+                        "legacy_version_file_disable_tools" => {
+                            settings.legacy_version_file_disable_tools =
+                                self.parse_string_array(&k, v)?.into_iter().collect()
+                        }
                         "always_keep_download" => {
                             settings.always_keep_download = Some(self.parse_bool(&k, v)?)
                         }
@@ -401,7 +405,8 @@ impl RtxToml {
                                 Some(self.parse_duration_minutes(&k, v)?)
                         }
                         "trusted_config_paths" => {
-                            settings.trusted_config_paths = self.parse_paths(&k, v)?;
+                            settings.trusted_config_paths =
+                                self.parse_paths(&k, v)?.into_iter().collect();
                         }
                         "verbose" => settings.verbose = Some(self.parse_bool(&k, v)?),
                         "asdf_compat" => settings.asdf_compat = Some(self.parse_bool(&k, v)?),
@@ -411,6 +416,10 @@ impl RtxToml {
                         }
                         "disable_default_shorthands" => {
                             settings.disable_default_shorthands = Some(self.parse_bool(&k, v)?)
+                        }
+                        "disable_tools" => {
+                            settings.disable_tools =
+                                self.parse_string_array(&k, v)?.into_iter().collect()
                         }
                         "log_level" => settings.log_level = Some(self.parse_log_level(&k, v)?),
                         "raw" => settings.raw = Some(self.parse_bool(&k, v)?),
@@ -516,6 +525,16 @@ impl RtxToml {
                 Ok(v)
             }
             _ => parse_error!(k, v, "string")?,
+        }
+    }
+
+    fn parse_string_array(&self, k: &String, v: &Item) -> Result<Vec<String>> {
+        match v
+            .as_array()
+            .map(|v| v.iter().map(|v| v.as_str().unwrap().to_string()).collect())
+        {
+            Some(v) => Ok(v),
+            _ => parse_error!(k, v, "array of strings")?,
         }
     }
 

--- a/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__fixture-2.snap
+++ b/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__fixture-2.snap
@@ -10,8 +10,11 @@ SettingsBuilder {
     always_keep_download: None,
     always_keep_install: None,
     legacy_version_file: None,
+    legacy_version_file_disable_tools: {
+        "disabled_tool_from_legacy_file",
+    },
     plugin_autoupdate_last_check_duration: None,
-    trusted_config_paths: [],
+    trusted_config_paths: {},
     verbose: Some(
         true,
     ),
@@ -19,6 +22,9 @@ SettingsBuilder {
     jobs: None,
     shorthands_file: None,
     disable_default_shorthands: None,
+    disable_tools: {
+        "disabled_tool",
+    },
     log_level: None,
     raw: None,
 }

--- a/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__fixture-6.snap
+++ b/src/config/config_file/snapshots/rtx__config__config_file__rtx_toml__tests__fixture-6.snap
@@ -21,6 +21,9 @@ node = 'https://github.com/jdxcode/rtx-node'
 [settings]
 verbose = true
 missing_runtime_behavior = 'warn'
+disable_tools = ['disabled_tool']
+legacy_version_file_disable_tools = ['disabled_tool_from_legacy_file']
 
 [alias.node]
 my_custom_node = '18'
+

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -308,6 +308,9 @@ fn load_tools(settings: &Settings) -> Result<ToolMap> {
         .map(|p| (p.name.clone(), Arc::new(p)))
         .collect::<Vec<_>>();
     tools.extend(plugins);
+    for tool in &settings.disable_tools {
+        tools.remove(tool);
+    }
     Ok(tools)
 }
 
@@ -323,6 +326,11 @@ fn load_legacy_files(settings: &Settings, tools: &ToolMap) -> BTreeMap<String, P
         .values()
         .collect_vec()
         .into_par_iter()
+        .filter(|tool| {
+            !settings
+                .legacy_version_file_disable_tools
+                .contains(&tool.name)
+        })
         .filter_map(|tool| match tool.legacy_filenames(settings) {
             Ok(filenames) => Some(
                 filenames

--- a/test/fixtures/.rtx.toml
+++ b/test/fixtures/.rtx.toml
@@ -17,6 +17,8 @@ node = 'https://github.com/jdxcode/rtx-node'
 [settings]
 verbose = true
 missing_runtime_behavior = 'warn'
+disable_tools = ['disabled_tool']
+legacy_version_file_disable_tools = ['disabled_tool_from_legacy_file']
 
 [alias.node]
 my_custom_node = '18'


### PR DESCRIPTION
This mainly adds 2 new settings:

* disable_tools: intended to be used for disabling core plugins entirely
* legacy_version_file_disable_tools: turn off legacy version file parsing for specific tools instead of disabling all of them

Fixes #618 