### PR TITLE
Update Nix install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,37 +389,10 @@ makepkg -si
 
 #### nix
 
-For NixOS or those using the Nix package manager:
+For the Nix package manager, at release 23.05 or later:
 
-```nix
-{
-  inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixpkgs-unstable";
-    flake-utils.url = "github:numtide/flake-utils";
-    rtx-flake = {
-      url = "github:jdxcode/rtx";
-      inputs.nixpkgs.follows = "nixpkgs";
-      inputs.flake-utils.follows = "flake-utils";
-    };
-  };
-
-  outputs = { self, nixpkgs, flake-utils, rtx-flake }:
-    flake-utils.lib.eachDefaultSystem(system:
-      let
-        pkgs = import nixpkgs {
-          inherit system;
-          overlays = [ rtx-flake.overlay ];
-        };
-      in {
-        devShells.default = pkgs.mkShell {
-          name = "my-dev-env";
-          nativeBuildInputs = with pkgs; [
-            rtx
-          ];
-        };
-      }
-    );
-}
+```
+nix-env -iA rtx
 ```
 
 You can also import the package directly using


### PR DESCRIPTION
This addresses https://github.com/jdxcode/rtx/issues/635

But!

It should only be merged _after_ `rtx` is available in some stable Nix release. See this backport PR for Nix 23.05: https://github.com/NixOS/nixpkgs/pull/241594