### PR TITLE
gpg sign install.sh

### DIFF
--- a/scripts/publish-s3.sh
+++ b/scripts/publish-s3.sh
@@ -5,18 +5,13 @@ set -euxo pipefail
 cache_day="max-age=86400,s-maxage=86400,public,immutable"
 cache_week="max-age=604800,s-maxage=604800,public,immutable"
 
-./rtx/scripts/render-install.sh >"$RELEASE_DIR"/install.sh
-echo "$RTX_VERSION" | tr -d 'v' >"$RELEASE_DIR"/VERSION
-
-cp "$RELEASE_DIR/rtx-latest-linux-x64" "$RELEASE_DIR/rtx-latest-linux-amd64"
-cp "$RELEASE_DIR/rtx-latest-macos-x64" "$RELEASE_DIR/rtx-latest-macos-amd64"
-
 aws s3 cp "$RELEASE_DIR/$RTX_VERSION" "s3://rtx.pub/$RTX_VERSION/" --cache-control "$cache_week" --no-progress --recursive
 
 aws s3 cp "$RELEASE_DIR" "s3://rtx.pub/" --cache-control "$cache_day" --no-progress --recursive --exclude "*" --include "rtx-latest-*"
 aws s3 cp "$RELEASE_DIR" "s3://rtx.pub/" --cache-control "$cache_day" --no-progress --content-type "text/plain" --recursive --exclude "*" --include "SHASUMS*"
 aws s3 cp "$RELEASE_DIR/VERSION" "s3://rtx.pub/" --cache-control "$cache_day" --no-progress --content-type "text/plain"
 aws s3 cp "$RELEASE_DIR/install.sh" "s3://rtx.pub/" --cache-control "$cache_day" --no-progress --content-type "text/plain"
+aws s3 cp "$RELEASE_DIR/install.sh.sig" "s3://rtx.pub/" --cache-control "$cache_day" --no-progress
 aws s3 cp "./rtx/schema/rtx.json" "s3://rtx.pub/schema/rtx.json" --cache-control "$cache_day" --no-progress --content-type "application/json"
 aws s3 cp "./rtx/schema/rtx.plugin.json" "s3://rtx.pub/schema/rtx.plugin.json" --cache-control "$cache_day" --no-progress --content-type "application/json"
 
@@ -38,6 +33,7 @@ curl -X POST "https://api.cloudflare.com/client/v4/zones/$CLOUDFLARE_ZONE_ID/pur
       "/VERSION",
       "/SHASUMS",
       "/install.sh",
+      "/install.sh.sig",
       "/rtx-latest-",
       "/rpm/repodata/",
       "/deb/dists/"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -44,10 +44,15 @@ for platform in "${platforms[@]}"; do
 done
 
 pushd "$RELEASE_DIR"
+echo "$RTX_VERSION" | tr -d 'v' >VERSION
+./rtx/scripts/render-install.sh >install.sh
+cp "rtx-latest-linux-x64" "rtx-latest-linux-amd64"
+cp "rtx-latest-macos-x64" "rtx-latest-macos-amd64"
 sha256sum ./rtx-latest-* >SHASUMS256.txt
 sha512sum ./rtx-latest-* >SHASUMS512.txt
 gpg --clearsign -u 408B88DB29DDE9E0 <SHASUMS256.txt >SHASUMS256.asc
 gpg --clearsign -u 408B88DB29DDE9E0 <SHASUMS512.txt >SHASUMS512.asc
+gpg -u 408B88DB29DDE9E0 --output install.sh.sig --sign install.sh
 popd
 
 pushd "$RELEASE_DIR/$RTX_VERSION"


### PR DESCRIPTION
I believe (since I have to cut a release to fully test) this makes it so you can verify the install.sh script with the following:

```
gpg --keyserver hkps://keys.openpgp.org --recv-keys 408B88DB29DDE9E0
curl https://rtx.pub/install.sh.sig | gpg --decrypt | sh
```
