### PR TITLE
remove version/outdated warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -850,10 +850,6 @@ installing plugins, e.g.: `rtx plugin install node https://github.com/asdf-vm/as
 Disables the specified tools. Separate with `,`. Generally used for core plugins but works with
 all.
 
-#### `RTX_HIDE_UPDATE_WARNING=1`
-
-This hides the warning that is displayed when a new version of rtx is available.
-
 #### `RTX_CONFIRM=yes|no`
 
 This will automatically answer yes or no to prompts. This is useful for scripting.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -49,18 +49,6 @@ Over time we should be able to move more plugins into being fully maintained by 
 `RTX_PARANOID=1` env var that, when set, will make changes to make rtx behave as securely as possible
 (e.g.: only using core plugins, only allowing plugins that use GPG verification of assets).
 
-## Privacy
-
-Currently the only "phoning home" that rtx does is with the weekly check for new versions. It does not send any
-data (except its version), but using the IP address I'm able to infer some (very) broad usage data for rtx. You
-may opt out of this behavior with `RTX_HIDE_UPDATE_WARNING=1`. You can also audit the [code](https://github.com/jdxcode/rtx/blob/main/src/cli/version.rs)
-yourself to see what it does.
-
-I would like to see some basic, but public analytics information. I think [homebrew](https://docs.brew.sh/Analytics)
-did a great job of doing this, and we'd have a similar model where the data is anonymous and publicly accessible.
-Doing so will help both me and plugin authors to know if we're building effective functionality. It's also a great way
-to get buy-in from organizations to do development with rtx (especially at large tech companies—they all _love_ numbers).
-
 ## Supported Versions
 
 The only supported version is the most recent one.

--- a/src/build_time.rs
+++ b/src/build_time.rs
@@ -1,8 +1,5 @@
-use chrono::{DateTime, FixedOffset, Months, Utc};
-use console::style;
+use chrono::{DateTime, FixedOffset};
 use once_cell::sync::Lazy;
-
-use crate::env::RTX_HIDE_UPDATE_WARNING;
 
 pub mod built_info {
     include!(concat!(env!("OUT_DIR"), "/built.rs"));
@@ -10,34 +7,3 @@ pub mod built_info {
 
 pub static BUILD_TIME: Lazy<DateTime<FixedOffset>> =
     Lazy::new(|| DateTime::parse_from_rfc2822(built_info::BUILT_TIME_UTC).unwrap());
-
-#[allow(dead_code)]
-pub fn init() {
-    if !*RTX_HIDE_UPDATE_WARNING
-        && BUILD_TIME.checked_add_months(Months::new(12)).unwrap() < Utc::now()
-    {
-        eprintln!("{}", render_outdated_message());
-    }
-}
-
-fn render_outdated_message() -> String {
-    let rtx = style("rtx").dim().for_stderr();
-    let mut output = vec![];
-    output.push(format!(
-        "{rtx} rtx has not been updated in over a year. Please update to the latest version."
-    ));
-    if cfg!(any(
-        feature = "self_update",
-        feature = "alpine",
-        feature = "brew",
-        feature = "deb",
-        feature = "rpm",
-    )) {
-        output.push(format!("{rtx} update with: `rtx self-update`"));
-    }
-    output.push(format!(
-        "{rtx} To hide this warning, set RTX_HIDE_OUTDATED_BUILD=1."
-    ));
-
-    output.join("\n")
-}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -213,28 +213,8 @@ impl Cli {
             external::execute(&config, command, sub_m, self.external_commands)?;
         }
         let cmd = Commands::from_arg_matches(&matches)?;
-        if !is_fast_command(&cmd) {
-            config.check_for_new_version();
-        }
         cmd.run(config, out)
     }
-}
-
-fn is_fast_command(cmd: &Commands) -> bool {
-    matches!(
-        cmd,
-        Commands::Version(..)
-            | Commands::Activate(..)
-            | Commands::Asdf(..)
-            | Commands::Completion(..)
-            | Commands::HookEnv(..)
-            | Commands::Direnv(..)
-            | Commands::Env(..)
-            | Commands::Exec(..)
-            | Commands::Shell(..)
-            | Commands::Where(..)
-            | Commands::Which(..)
-    )
 }
 
 impl Default for Cli {

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -16,13 +16,12 @@ use crate::config::config_file::legacy_version::LegacyVersionFile;
 use crate::config::config_file::rtx_toml::RtxToml;
 use crate::config::config_file::{ConfigFile, ConfigFileType};
 use crate::config::tracking::Tracker;
-use crate::env::CI;
 use crate::file::display_path;
 use crate::plugins::core::{CORE_PLUGINS, EXPERIMENTAL_CORE_PLUGINS};
 use crate::plugins::{ExternalPlugin, Plugin, PluginName, PluginType};
 use crate::shorthands::{get_shorthands, Shorthands};
 use crate::tool::Tool;
-use crate::{cli, dirs, duration, env, file, hook_env};
+use crate::{dirs, env, file, hook_env};
 
 pub mod config_file;
 mod settings;
@@ -230,19 +229,6 @@ impl Config {
             .flatten()
             .collect();
         Ok(config_files)
-    }
-
-    pub fn check_for_new_version(&self) {
-        if *CI || !console::user_attended_stderr() || *env::RTX_HIDE_UPDATE_WARNING {
-            return;
-        }
-        if let Some(latest) = cli::version::check_for_new_version(duration::WEEKLY) {
-            warn!(
-                "newer rtx version {} available, currently on {}",
-                latest,
-                env!("CARGO_PKG_VERSION")
-            );
-        }
     }
 
     pub fn is_plugin_hidden(&self, plugin_name: &PluginName) -> bool {

--- a/src/duration.rs
+++ b/src/duration.rs
@@ -2,4 +2,4 @@ pub use std::time::Duration;
 
 pub(crate) const HOURLY: Duration = Duration::from_secs(60 * 60);
 pub(crate) const DAILY: Duration = Duration::from_secs(60 * 60 * 24);
-pub(crate) const WEEKLY: Duration = Duration::from_secs(60 * 60 * 24 * 7);
+//pub(crate) const WEEKLY: Duration = Duration::from_secs(60 * 60 * 24 * 7);

--- a/src/env.rs
+++ b/src/env.rs
@@ -76,8 +76,6 @@ pub static PATH: Lazy<Vec<PathBuf>> = Lazy::new(|| match PRISTINE_ENV.get("PATH"
 pub static DIRENV_DIFF: Lazy<Option<String>> = Lazy::new(|| var("DIRENV_DIFF").ok());
 pub static RTX_CONFIRM: Lazy<Confirm> = Lazy::new(|| var_confirm("RTX_CONFIRM"));
 pub static RTX_EXPERIMENTAL: Lazy<bool> = Lazy::new(|| var_is_true("RTX_EXPERIMENTAL"));
-pub static RTX_HIDE_UPDATE_WARNING: Lazy<bool> =
-    Lazy::new(|| var_is_true("RTX_HIDE_UPDATE_WARNING"));
 pub static RTX_ASDF_COMPAT: Lazy<bool> = Lazy::new(|| var_is_true("RTX_ASDF_COMPAT"));
 pub static RTX_SHORTHANDS_FILE: Lazy<Option<PathBuf>> =
     Lazy::new(|| var_path("RTX_SHORTHANDS_FILE"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,7 +53,6 @@ mod toolset;
 mod ui;
 
 fn main() -> Result<()> {
-    build_time::init();
     color_eyre::install()?;
     let log_level = *env::RTX_LOG_LEVEL;
     logger::init(log_level, *env::RTX_LOG_FILE_LEVEL);


### PR DESCRIPTION
These made sense when rtx was young, but I think that it is
stable enough we do not need to bother users with update messages so much.
