### PR TITLE
added --prefix flag to ls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1875,6 +1875,9 @@ Options:
   -m, --missing
           Display missing tool versions
 
+      --prefix <PREFIX>
+          Display versions matching this prefix
+
 Examples:
   $ rtx ls
   ⏵  node     20.0.0 (set by ~/src/myapp/.tool-versions)

--- a/completions/_rtx
+++ b/completions/_rtx
@@ -782,6 +782,7 @@ the current value of .tool-versions/.rtx.toml will be displayed:' \
 _arguments "${_arguments_options[@]}" \
 '-p+[Only show tool versions from \[PLUGIN\]]:PLUGIN: ' \
 '--plugin=[Only show tool versions from \[PLUGIN\]]:PLUGIN: ' \
+'--prefix=[Display versions matching this prefix]:PREFIX: ' \
 '-j+[Number of plugins and runtimes to install in parallel
 default\: 4]: : ' \
 '--jobs=[Number of plugins and runtimes to install in parallel

--- a/completions/rtx.bash
+++ b/completions/rtx.bash
@@ -2295,7 +2295,7 @@ _rtx() {
             return 0
             ;;
         rtx__ls)
-            opts="-p -c -i -m -j -r -v -h --plugin --current --installed --parseable --json --missing --debug --install-missing --jobs --log-level --raw --trace --verbose --help [PLUGIN_ARG]"
+            opts="-p -c -i -m -j -r -v -h --plugin --current --installed --parseable --json --missing --prefix --debug --install-missing --jobs --log-level --raw --trace --verbose --help [PLUGIN_ARG]"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0
@@ -2306,6 +2306,10 @@ _rtx() {
                     return 0
                     ;;
                 -p)
+                    COMPREPLY=($(compgen -f "${cur}"))
+                    return 0
+                    ;;
+                --prefix)
                     COMPREPLY=($(compgen -f "${cur}"))
                     return 0
                     ;;

--- a/completions/rtx.fish
+++ b/completions/rtx.fish
@@ -378,6 +378,7 @@ complete -c rtx -n "__fish_seen_subcommand_from local" -l trace -d 'Sets log lev
 complete -c rtx -n "__fish_seen_subcommand_from local" -s v -l verbose -d 'Show installation output'
 complete -c rtx -n "__fish_seen_subcommand_from local" -s h -l help -d 'Print help (see more with \'--help\')'
 complete -c rtx -n "__fish_seen_subcommand_from ls" -s p -l plugin -d 'Only show tool versions from [PLUGIN]' -r
+complete -c rtx -n "__fish_seen_subcommand_from ls" -l prefix -d 'Display versions matching this prefix' -r
 complete -c rtx -n "__fish_seen_subcommand_from ls" -s j -l jobs -d 'Number of plugins and runtimes to install in parallel
 default: 4' -r
 complete -c rtx -n "__fish_seen_subcommand_from ls" -l log-level -d 'Set the log output verbosity' -r

--- a/src/cli/snapshots/rtx__cli__ls__tests__ls_prefix.snap
+++ b/src/cli/snapshots/rtx__cli__ls__tests__ls_prefix.snap
@@ -1,0 +1,6 @@
+---
+source: src/cli/ls.rs
+expression: output
+---
+tiny 3.1.0 ~/cwd/.test-tool-versions 3
+


### PR DESCRIPTION
This makes rtx somewhat compatible with asdf syntax like:

    asdf list nodejs 16

More work could be done here so that syntax works as well but it's a little tricky to handle all the various ways it should be handled, e.g.:

    rtx ls node@16
    rtx ls node 16

And then think about how it should behave if `--plugin` is set too.