### PR TITLE
added --installed option to latest command

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ v20.0.0
   - [`rtx exec [OPTIONS] [TOOL@VERSION]... [-- <COMMAND>...]`](#rtx-exec-options-toolversion----command)
   - [`rtx implode [OPTIONS]`](#rtx-implode-options)
   - [`rtx install [OPTIONS] [TOOL@VERSION]...`](#rtx-install-options-toolversion)
-  - [`rtx latest <TOOL@VERSION>`](#rtx-latest-toolversion)
+  - [`rtx latest [OPTIONS] <TOOL@VERSION>`](#rtx-latest-options-toolversion)
   - [`rtx ls [OPTIONS]`](#rtx-ls-options)
   - [`rtx ls-remote <TOOL@VERSION> [PREFIX]`](#rtx-ls-remote-toolversion-prefix)
   - [`rtx outdated [TOOL@VERSION]...`](#rtx-outdated-toolversion)
@@ -1832,16 +1832,20 @@ Examples:
   $ rtx install node         # install version specified in .tool-versions or .rtx.toml
   $ rtx install                # installs everything specified in .tool-versions or .rtx.toml
 ```
-### `rtx latest <TOOL@VERSION>`
+### `rtx latest [OPTIONS] <TOOL@VERSION>`
 
 ```
 Gets the latest available version for a plugin
 
-Usage: latest <TOOL@VERSION>
+Usage: latest [OPTIONS] <TOOL@VERSION>
 
 Arguments:
   <TOOL@VERSION>
           Tool to get the latest version of
+
+Options:
+  -i, --installed
+          Show latest installed instead of available version
 
 Examples:
   $ rtx latest node@20  # get the latest version of node 20

--- a/completions/_rtx
+++ b/completions/_rtx
@@ -730,6 +730,8 @@ default\: 4]: : ' \
 '--jobs=[Number of plugins and runtimes to install in parallel
 default\: 4]: : ' \
 '--log-level=[Set the log output verbosity]:LEVEL: ' \
+'-i[Show latest installed instead of available version]' \
+'--installed[Show latest installed instead of available version]' \
 '--debug[Sets log level to debug]' \
 '--install-missing[Automatically install missing tools]' \
 '-r[Directly pipe stdin/stdout/stderr to user.

--- a/completions/rtx.bash
+++ b/completions/rtx.bash
@@ -2239,7 +2239,7 @@ _rtx() {
             return 0
             ;;
         rtx__latest)
-            opts="-j -r -v -h --debug --install-missing --jobs --log-level --raw --trace --verbose --help <TOOL@VERSION> [ASDF_VERSION]"
+            opts="-i -j -r -v -h --installed --debug --install-missing --jobs --log-level --raw --trace --verbose --help <TOOL@VERSION> [ASDF_VERSION]"
             if [[ ${cur} == -* || ${COMP_CWORD} -eq 2 ]] ; then
                 COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
                 return 0

--- a/completions/rtx.fish
+++ b/completions/rtx.fish
@@ -353,6 +353,7 @@ complete -c rtx -n "__fish_seen_subcommand_from install" -s h -l help -d 'Print 
 complete -c rtx -n "__fish_seen_subcommand_from latest" -s j -l jobs -d 'Number of plugins and runtimes to install in parallel
 default: 4' -r
 complete -c rtx -n "__fish_seen_subcommand_from latest" -l log-level -d 'Set the log output verbosity' -r
+complete -c rtx -n "__fish_seen_subcommand_from latest" -s i -l installed -d 'Show latest installed instead of available version'
 complete -c rtx -n "__fish_seen_subcommand_from latest" -l debug -d 'Sets log level to debug'
 complete -c rtx -n "__fish_seen_subcommand_from latest" -l install-missing -d 'Automatically install missing tools'
 complete -c rtx -n "__fish_seen_subcommand_from latest" -s r -l raw -d 'Directly pipe stdin/stdout/stderr to user.

--- a/src/cli/latest.rs
+++ b/src/cli/latest.rs
@@ -20,6 +20,10 @@ pub struct Latest {
     /// used for asdf compatibility
     #[clap(hide = true)]
     asdf_version: Option<String>,
+
+    /// Show latest installed instead of available version
+    #[clap(short, long)]
+    installed: bool,
 }
 
 impl Command for Latest {
@@ -45,7 +49,12 @@ impl Command for Latest {
             prefix = Some(config.resolve_alias(&plugin.name, &v)?);
         }
 
-        if let Some(version) = plugin.latest_version(&config.settings, prefix)? {
+        let latest_version = if self.installed {
+            plugin.latest_installed_version(prefix)?
+        } else {
+            plugin.latest_version(&config.settings, prefix)?
+        };
+        if let Some(version) = latest_version {
             rtxprintln!(out, "{}", version);
         }
         Ok(())
@@ -83,6 +92,11 @@ mod tests {
     fn test_latest_system() {
         let err = assert_cli_err!("latest", "dummy@system");
         assert_display_snapshot!(err);
+    }
+
+    #[test]
+    fn test_latest_installed() {
+        assert_cli_snapshot!("latest", "dummy");
     }
 
     #[test]

--- a/src/cli/snapshots/rtx__cli__latest__tests__latest_installed.snap
+++ b/src/cli/snapshots/rtx__cli__latest__tests__latest_installed.snap
@@ -1,0 +1,6 @@
+---
+source: src/cli/latest.rs
+expression: output
+---
+2.0.0
+

--- a/src/toolset/tool_version.rs
+++ b/src/toolset/tool_version.rs
@@ -124,7 +124,7 @@ impl ToolVersion {
 
         if v == "latest" {
             if !latest_versions {
-                if let Some(v) = tool.latest_installed_version()? {
+                if let Some(v) = tool.latest_installed_version(None)? {
                     return build(v);
                 }
             }


### PR DESCRIPTION
This provides an alternative way (from #654) that closes a gap where you could not easily get installed versions matching a prefix

Fixes #646