### PR TITLE
shells: add special nix behavior

### DIFF
--- a/src/shell/bash.rs
+++ b/src/shell/bash.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use indoc::formatdoc;
 
-use crate::shell::{is_dir_in_path, Shell};
+use crate::shell::{is_dir_in_path, is_dir_not_in_nix, Shell};
 
 #[derive(Default)]
 pub struct Bash {}
@@ -12,7 +12,7 @@ impl Shell for Bash {
         let dir = exe.parent().unwrap();
         let status = if status { " --status" } else { "" };
         let mut out = String::new();
-        if !is_dir_in_path(dir) {
+        if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) {
             out.push_str(&format!("export PATH=\"{}:$PATH\"\n", dir.display()));
         }
         out.push_str(&formatdoc! {r#"
@@ -81,6 +81,13 @@ mod tests {
     fn test_hook_init() {
         let bash = Bash::default();
         let exe = Path::new("/some/dir/rtx");
+        assert_snapshot!(bash.activate(exe, true));
+    }
+
+    #[test]
+    fn test_hook_init_nix() {
+        let bash = Bash::default();
+        let exe = Path::new("/nix/store/rtx");
         assert_snapshot!(bash.activate(exe, true));
     }
 

--- a/src/shell/fish.rs
+++ b/src/shell/fish.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use indoc::formatdoc;
 
-use crate::shell::{is_dir_in_path, Shell};
+use crate::shell::{is_dir_in_path, is_dir_not_in_nix, Shell};
 
 #[derive(Default)]
 pub struct Fish {}
@@ -14,7 +14,7 @@ impl Shell for Fish {
         let description = "'Update rtx environment when changing directories'";
         let mut out = String::new();
 
-        if !is_dir_in_path(dir) {
+        if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) {
             out.push_str(&format!("fish_add_path -g {dir}\n", dir = dir.display()));
         }
 
@@ -100,6 +100,13 @@ mod tests {
     fn test_hook_init() {
         let fish = Fish::default();
         let exe = Path::new("/some/dir/rtx");
+        assert_snapshot!(fish.activate(exe, true));
+    }
+
+    #[test]
+    fn test_hook_init_nix() {
+        let fish = Fish::default();
+        let exe = Path::new("/nix/store/rtx");
         assert_snapshot!(fish.activate(exe, true));
     }
 

--- a/src/shell/mod.rs
+++ b/src/shell/mod.rs
@@ -74,3 +74,9 @@ pub fn is_dir_in_path(dir: &Path) -> bool {
         .into_iter()
         .any(|p| p.canonicalize().unwrap_or(p) == dir)
 }
+
+pub fn is_dir_not_in_nix(dir: &Path) -> bool {
+    !dir.canonicalize()
+        .unwrap_or(dir.to_path_buf())
+        .starts_with("/nix/")
+}

--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -2,7 +2,7 @@ use std::{fmt::Display, path::Path};
 
 use indoc::formatdoc;
 
-use crate::shell::{is_dir_in_path, Shell};
+use crate::shell::{is_dir_in_path, is_dir_not_in_nix, Shell};
 
 #[derive(Default)]
 pub struct Nushell {}
@@ -29,7 +29,7 @@ impl Shell for Nushell {
         let status = if status { " --status" } else { "" };
         let mut out = String::new();
 
-        if !is_dir_in_path(dir) {
+        if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) {
             out.push_str(&format!(
                 "let-env PATH = ($env.PATH | prepend '{}')\n", // TODO: set PATH as Path on windows
                 dir.display()
@@ -124,6 +124,13 @@ mod tests {
     fn test_hook_init() {
         let nushell = Nushell::default();
         let exe = Path::new("/some/dir/rtx");
+        assert_snapshot!(nushell.activate(exe, true));
+    }
+
+    #[test]
+    fn test_hook_init_nix() {
+        let nushell = Nushell::default();
+        let exe = Path::new("/nix/store/rtx");
         assert_snapshot!(nushell.activate(exe, true));
     }
 

--- a/src/shell/snapshots/rtx__shell__bash__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/rtx__shell__bash__tests__hook_init_nix.snap
@@ -1,0 +1,34 @@
+---
+source: src/shell/bash.rs
+expression: "bash.activate(exe, true)"
+---
+export RTX_SHELL=bash
+
+rtx() {
+  local command
+  command="${1:-}"
+  if [ "$#" = 0 ]; then
+    command rtx
+    return
+  fi
+  shift
+
+  case "$command" in
+  deactivate|shell)
+    eval "$(command rtx "$command" "$@")"
+    ;;
+  *)
+    command rtx "$command" "$@"
+    ;;
+  esac
+}
+
+_rtx_hook() {
+  local previous_exit_status=$?;
+  eval "$(rtx hook-env --status -s bash)";
+  return $previous_exit_status;
+};
+if ! [[ "${PROMPT_COMMAND:-}" =~ _rtx_hook ]]; then
+  PROMPT_COMMAND="_rtx_hook${PROMPT_COMMAND:+;$PROMPT_COMMAND}"
+fi
+

--- a/src/shell/snapshots/rtx__shell__fish__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/rtx__shell__fish__tests__hook_init_nix.snap
@@ -1,0 +1,47 @@
+---
+source: src/shell/fish.rs
+expression: "fish.activate(exe, true)"
+---
+set -gx RTX_SHELL fish
+
+function rtx
+  if test (count $argv) -eq 0
+    command rtx
+    return
+  end
+
+  set command $argv[1]
+  set -e argv[1]
+
+  switch "$command"
+  case deactivate shell
+    source (command rtx "$command" $argv|psub)
+  case '*'
+    command rtx "$command" $argv
+  end
+end
+
+function __rtx_env_eval --on-event fish_prompt --description 'Update rtx environment when changing directories';
+    rtx hook-env --status -s fish | source;
+
+    if test "$rtx_fish_mode" != "disable_arrow";
+        function __rtx_cd_hook --on-variable PWD --description 'Update rtx environment when changing directories';
+            if test "$rtx_fish_mode" = "eval_after_arrow";
+                set -g __rtx_env_again 0;
+            else;
+                rtx hook-env --status -s fish | source;
+            end;
+        end;
+    end;
+end;
+
+function __rtx_env_eval_2 --on-event fish_preexec --description 'Update rtx environment when changing directories';
+    if set -q __rtx_env_again;
+        set -e __rtx_env_again;
+        rtx hook-env --status -s fish | source;
+        echo;
+    end;
+
+    functions --erase __rtx_cd_hook;
+end;
+

--- a/src/shell/snapshots/rtx__shell__nushell__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/rtx__shell__nushell__tests__hook_init_nix.snap
@@ -1,0 +1,59 @@
+---
+source: src/shell/nushell.rs
+assertion_line: 134
+expression: "nushell.activate(exe, true)"
+---
+export-env {
+  let-env RTX_SHELL = "nu"
+  
+  let-env config = ($env.config | upsert hooks {
+      pre_prompt: [{
+      condition: {|| "RTX_SHELL" in $env }
+      code: {|| rtx_hook }
+      }]
+      env_change: {
+          PWD: [{
+          condition: {|| "RTX_SHELL" in $env }
+          code: {|| rtx_hook }
+          }]
+      }
+  })
+}
+  
+def "parse vars" [] {
+  $in | lines | parse "{op},{name},{value}"
+}
+  
+def-env rtx [command?: string, --help, ...rest: string] {
+  let commands = ["shell", "deactivate"]
+  
+  if ($command == null) {
+    ^"/nix/store/rtx"
+  } else if ($command == "activate") {
+    let-env RTX_SHELL = "nu"
+  } else if ($command in $commands) {
+    ^"/nix/store/rtx" $command $rest
+    | parse vars
+    | update-env
+  } else {
+    ^"/nix/store/rtx" $command $rest
+  }
+}
+  
+def-env "update-env" [] {
+  for $var in $in {
+    if $var.op == "set" {
+      let-env $var.name = $"($var.value)"
+    } else if $var.op == "hide" {
+      hide-env $var.name
+    }
+  }
+}
+  
+def-env rtx_hook [] {
+  ^"/nix/store/rtx" hook-env --status -s nu
+    | parse vars
+    | update-env
+}
+
+

--- a/src/shell/snapshots/rtx__shell__xonsh__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/rtx__shell__xonsh__tests__hook_init_nix.snap
@@ -1,0 +1,12 @@
+---
+source: src/shell/xonsh.rs
+expression: "xonsh.activate(exe, true)"
+---
+from os               import environ
+from xonsh.built_ins  import XSH
+
+def listen_prompt(): # Hook Events
+  execx($(/nix/store/rtx hook-env --status -s xonsh))
+
+XSH.builtins.events.on_pre_prompt(listen_prompt) # Activate hook: before showing the prompt
+

--- a/src/shell/snapshots/rtx__shell__zsh__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/rtx__shell__zsh__tests__hook_init_nix.snap
@@ -1,0 +1,37 @@
+---
+source: src/shell/zsh.rs
+expression: "zsh.activate(exe, true)"
+---
+export RTX_SHELL=zsh
+
+rtx() {
+  local command
+  command="${1:-}"
+  if [ "$#" = 0 ]; then
+    command rtx
+    return
+  fi
+  shift
+
+  case "$command" in
+  deactivate|shell)
+    eval "$(command rtx "$command" "$@")"
+    ;;
+  *)
+    command rtx "$command" "$@"
+    ;;
+  esac
+}
+
+_rtx_hook() {
+  eval "$(rtx hook-env --status -s zsh)";
+}
+typeset -ag precmd_functions;
+if [[ -z "${precmd_functions[(r)_rtx_hook]+1}" ]]; then
+  precmd_functions=( _rtx_hook ${precmd_functions[@]} )
+fi
+typeset -ag chpwd_functions;
+if [[ -z "${chpwd_functions[(r)_rtx_hook]+1}" ]]; then
+  chpwd_functions=( _rtx_hook ${chpwd_functions[@]} )
+fi
+

--- a/src/shell/xonsh.rs
+++ b/src/shell/xonsh.rs
@@ -2,7 +2,7 @@ use std::path::Path;
 
 use indoc::formatdoc;
 
-use crate::shell::{is_dir_in_path, Shell};
+use crate::shell::{is_dir_in_path, is_dir_not_in_nix, Shell};
 
 #[derive(Default)]
 pub struct Xonsh {}
@@ -53,7 +53,7 @@ impl Shell for Xonsh {
             from xonsh.built_ins  import XSH
 
         "#});
-        if !is_dir_in_path(dir) {
+        if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) {
             let dir_str = dir.to_string_lossy();
             let dir_esc = xonsh_escape_sq(&dir_str);
             out.push_str(&formatdoc! {r#"
@@ -133,6 +133,13 @@ mod tests {
     fn test_hook_init() {
         let xonsh = Xonsh::default();
         let exe = Path::new("/some/dir/rtx");
+        insta::assert_snapshot!(xonsh.activate(exe, true));
+    }
+
+    #[test]
+    fn test_hook_init_nix() {
+        let xonsh = Xonsh::default();
+        let exe = Path::new("/nix/store/rtx");
         insta::assert_snapshot!(xonsh.activate(exe, true));
     }
 

--- a/src/shell/zsh.rs
+++ b/src/shell/zsh.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use indoc::formatdoc;
 
 use crate::shell::bash::Bash;
-use crate::shell::{is_dir_in_path, Shell};
+use crate::shell::{is_dir_in_path, is_dir_not_in_nix, Shell};
 
 #[derive(Default)]
 pub struct Zsh {}
@@ -16,7 +16,7 @@ impl Shell for Zsh {
 
         // much of this is from direnv
         // https://github.com/direnv/direnv/blob/cb5222442cb9804b1574954999f6073cc636eff0/internal/cmd/shell_zsh.go#L10-L22
-        if !is_dir_in_path(dir) {
+        if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) {
             out.push_str(&format!("export PATH=\"{}:$PATH\"\n", dir.display()));
         }
         out.push_str(&formatdoc! {r#"
@@ -86,6 +86,13 @@ mod tests {
     fn test_hook_init() {
         let zsh = Zsh::default();
         let exe = Path::new("/some/dir/rtx");
+        assert_snapshot!(zsh.activate(exe, true));
+    }
+
+    #[test]
+    fn test_hook_init_nix() {
+        let zsh = Zsh::default();
+        let exe = Path::new("/nix/store/rtx");
         assert_snapshot!(zsh.activate(exe, true));
     }
 


### PR DESCRIPTION
Following the discussion: https://github.com/jdxcode/rtx/discussions/671#discussioncomment-6417337, adding a special behavior for when `rtx` is installed under the `/nix` prefix: do not add `rtx` binary to the `PATH` environment variable.