### PR TITLE
feat: add envs for rtx go core plugin

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -166,6 +166,8 @@ pub static RTX_GO_DEFAULT_PACKAGES_FILE: Lazy<PathBuf> = Lazy::new(|| {
     var_path("RTX_GO_DEFAULT_PACKAGES_FILE").unwrap_or_else(|| HOME.join(".default-go-packages"))
 });
 pub static RTX_GO_SKIP_CHECKSUM: Lazy<bool> = Lazy::new(|| var_is_true("RTX_GO_SKIP_CHECKSUM"));
+pub static RTX_GO_REPO: Lazy<String> = Lazy::new(|| "https://github.com/golang/go");
+pub static RTX_GO_DOWNLOAD_MIRROR: Lazy<String> = Lazy::new(|| "https://dl.google.com/go");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Confirm {

--- a/src/env.rs
+++ b/src/env.rs
@@ -167,8 +167,11 @@ pub static RTX_GO_DEFAULT_PACKAGES_FILE: Lazy<PathBuf> = Lazy::new(|| {
     var_path("RTX_GO_DEFAULT_PACKAGES_FILE").unwrap_or_else(|| HOME.join(".default-go-packages"))
 });
 pub static RTX_GO_SKIP_CHECKSUM: Lazy<bool> = Lazy::new(|| var_is_true("RTX_GO_SKIP_CHECKSUM"));
-pub static RTX_GO_REPO: Lazy<String> = Lazy::new(|| var("RTX_GO_REPO").unwrap_or_else(|_| "https://github.com/golang/go".into()));
-pub static RTX_GO_DOWNLOAD_MIRROR: Lazy<String> = Lazy::new(|| var("RTX_GO_DOWNLOAD_MIRROR").unwrap_or_else(|_| "https://dl.google.com/go".into()));
+pub static RTX_GO_REPO: Lazy<String> =
+    Lazy::new(|| var("RTX_GO_REPO").unwrap_or_else(|_| "https://github.com/golang/go".into()));
+pub static RTX_GO_DOWNLOAD_MIRROR: Lazy<String> = Lazy::new(|| {
+    var("RTX_GO_DOWNLOAD_MIRROR").unwrap_or_else(|_| "https://dl.google.com/go".into())
+});
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Confirm {

--- a/src/env.rs
+++ b/src/env.rs
@@ -168,7 +168,7 @@ pub static RTX_GO_DEFAULT_PACKAGES_FILE: Lazy<PathBuf> = Lazy::new(|| {
 });
 pub static RTX_GO_SKIP_CHECKSUM: Lazy<bool> = Lazy::new(|| var_is_true("RTX_GO_SKIP_CHECKSUM"));
 pub static RTX_GO_REPO: Lazy<String> = Lazy::new(|| var("RTX_GO_REPO").unwrap_or_else(|_| "https://github.com/golang/go".into()));
-pub static RTX_GO_DOWNLOAD_MIRROR: Lazy<String> = Lazy::new(|| "https://dl.google.com/go");
+pub static RTX_GO_DOWNLOAD_MIRROR: Lazy<String> = Lazy::new(|| var("RTX_GO_DOWNLOAD_MIRROR").unwrap_or_else(|_| "https://dl.google.com/go".into()));
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Confirm {

--- a/src/env.rs
+++ b/src/env.rs
@@ -162,11 +162,12 @@ pub static RTX_RUBY_DEFAULT_PACKAGES_FILE: Lazy<PathBuf> = Lazy::new(|| {
     var_path("RTX_RUBY_DEFAULT_PACKAGES_FILE").unwrap_or_else(|| HOME.join(".default-gems"))
 });
 
+// go
 pub static RTX_GO_DEFAULT_PACKAGES_FILE: Lazy<PathBuf> = Lazy::new(|| {
     var_path("RTX_GO_DEFAULT_PACKAGES_FILE").unwrap_or_else(|| HOME.join(".default-go-packages"))
 });
 pub static RTX_GO_SKIP_CHECKSUM: Lazy<bool> = Lazy::new(|| var_is_true("RTX_GO_SKIP_CHECKSUM"));
-pub static RTX_GO_REPO: Lazy<String> = Lazy::new(|| "https://github.com/golang/go");
+pub static RTX_GO_REPO: Lazy<String> = Lazy::new(|| var("RTX_GO_REPO").unwrap_or_else(|_| "https://github.com/golang/go".into()));
 pub static RTX_GO_DOWNLOAD_MIRROR: Lazy<String> = Lazy::new(|| "https://dl.google.com/go");
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -97,7 +97,7 @@ impl GoPlugin {
     fn download(&self, tv: &ToolVersion, pr: &ProgressReport) -> Result<PathBuf> {
         let http = http::Client::new()?;
         let filename = format!("go{}.{}-{}.tar.gz", tv.version, platform(), arch());
-        let tarball_url = format!("{}/{}", env::RTX_GO_DOWNLOAD_MIRROR, &filename);
+        let tarball_url = format!("{}/{}", &*env::RTX_GO_DOWNLOAD_MIRROR, &filename);
         let tarball_path = tv.download_path().join(filename);
 
         pr.set_message(format!("downloading {}", &tarball_url));

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -33,7 +33,7 @@ impl GoPlugin {
                 "git",
                 "ls-remote",
                 "--tags",
-                env::RTX_GO_REPO,
+                &*env::RTX_GO_REPO,
                 "go*"
             )
             .read()?;

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -33,7 +33,7 @@ impl GoPlugin {
                 "git",
                 "ls-remote",
                 "--tags",
-                "https://github.com/golang/go",
+                env::RTX_GO_REPO,
                 "go*"
             )
             .read()?;
@@ -97,7 +97,7 @@ impl GoPlugin {
     fn download(&self, tv: &ToolVersion, pr: &ProgressReport) -> Result<PathBuf> {
         let http = http::Client::new()?;
         let filename = format!("go{}.{}-{}.tar.gz", tv.version, platform(), arch());
-        let tarball_url = format!("https://dl.google.com/go/{}", &filename);
+        let tarball_url = format!("{}/{}", env::RTX_GO_DOWNLOAD_MIRROR, &filename);
         let tarball_path = tv.download_path().join(filename);
 
         pr.set_message(format!("downloading {}", &tarball_url));

--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -29,14 +29,8 @@ impl GoPlugin {
 
     fn fetch_remote_versions(&self) -> Result<Vec<String>> {
         CorePlugin::run_fetch_task_with_timeout(move || {
-            let output = cmd!(
-                "git",
-                "ls-remote",
-                "--tags",
-                &*env::RTX_GO_REPO,
-                "go*"
-            )
-            .read()?;
+            let repo = &*env::RTX_GO_REPO;
+            let output = cmd!("git", "ls-remote", "--tags", repo, "go*").read()?;
             let lines = output.split('\n');
             let versions = lines.map(|s| s.split("/go").last().unwrap_or_default().to_string())
                 .filter(|s| !s.is_empty())


### PR DESCRIPTION
https://github.com/jdxcode/rtx/discussions/677

for env names: `RTX_GO_REPO` `RTX_GO_REPOSITORY` `RTX_GO_DOWNLOAD_MIRROR` `RTX_GOLANG_DOWNLOAD_MIRROR`, since there is `RTX_GO_SKIP_CHECKSUM` already in [src/env.rs](https://github.com/jdxcode/rtx/blob/main/src/env.rs#L168C12-L168C32), I choose short version too.

