### PR TITLE
use latest version for `rtx use`

### DIFF
--- a/src/cli/local.rs
+++ b/src/cli/local.rs
@@ -141,6 +141,7 @@ pub fn local(
 
 fn install_missing_runtimes(config: &mut Config, cf: &dyn ConfigFile) -> Result<()> {
     let mut ts = cf.to_toolset().clone();
+    ts.latest_versions = true;
     ts.resolve(config);
     if !ts.list_missing_versions(config).is_empty() {
         let mpr = MultiProgressReport::new(config.show_progress_bars());


### PR DESCRIPTION
This makes it so if you run `rtx use node@20` that will use the latest version of node@20, not the latest installed version.
