### PR TITLE
Update ruby.md

### DIFF
--- a/docs/ruby.md
+++ b/docs/ruby.md
@@ -67,5 +67,5 @@ update:
 
 ```bash
 rtx cache clean
-rtx ls-remote node
+rtx ls-remote ruby
 ```


### PR DESCRIPTION
Change the remote version list fetching command to be for Ruby, which is more appropriate for the docs of this plugin.

This list Ruby versions command actually fails (for me at least) see #692.