### PR TITLE
Fix for breaking changes in Nushell 0.83

### DIFF
--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -31,16 +31,16 @@ impl Shell for Nushell {
 
         if is_dir_not_in_nix(dir) && !is_dir_in_path(dir) {
             out.push_str(&format!(
-                "let-env PATH = ($env.PATH | prepend '{}')\n", // TODO: set PATH as Path on windows
+                "$env.PATH = ($env.PATH | prepend '{}')\n", // TODO: set PATH as Path on windows
                 dir.display()
             ));
         }
 
         out.push_str(&formatdoc! {r#"
           export-env {{
-            let-env RTX_SHELL = "nu"
+            $env.RTX_SHELL = "nu"
             
-            let-env config = ($env.config | upsert hooks {{
+            $env.config = ($env.config | upsert hooks {{
                 pre_prompt: [{{
                 condition: {{|| "RTX_SHELL" in $env }}
                 code: {{|| rtx_hook }}
@@ -64,7 +64,7 @@ impl Shell for Nushell {
             if ($command == null) {{
               ^"{exe}"
             }} else if ($command == "activate") {{
-              let-env RTX_SHELL = "nu"
+              $env.RTX_SHELL = "nu"
             }} else if ($command in $commands) {{
               ^"{exe}" $command $rest
               | parse vars
@@ -77,7 +77,7 @@ impl Shell for Nushell {
           def-env "update-env" [] {{
             for $var in $in {{
               if $var.op == "set" {{
-                let-env $var.name = $"($var.value)"
+                load-env {$var.name: $var.value}
               }} else if $var.op == "hide" {{
                 hide-env $var.name
               }}


### PR DESCRIPTION
As per the release notes for Nushell 0.83:
```
PLEASE NOTE: there are some big breaking changes in this release. These include:
- Removal of let-env (now use the $env.FOO = "BAR" form instead)
```

These changes remove the `let-env` keyword from the generated `rtx.nu` script. Tested by locally tweaking rtx.nu.


### References:
[Nushell 0.83 Release Blog](https://www.nushell.sh/blog/2023-07-25-nushell_0_83.html#breaking-changes)