### PR TITLE
Promote /etc/apt/keyrings over /usr/share/keyrings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,8 +107,9 @@ This is for arm64, but you can change the arch to amd64 if you want.
 finch run -ti --rm ubuntu
 apt update -y
 apt install gpg sudo wget curl
-wget -qO - https://rtx.pub/gpg-key.pub | gpg --dearmor | sudo tee /usr/share/keyrings/rtx-archive-keyring.gpg 1> /dev/null
-echo "deb [signed-by=/usr/share/keyrings/rtx-archive-keyring.gpg arch=arm64] https://rtx.pub/deb stable main" | sudo tee /etc/apt/sources.list.d/rtx.list
+sudo install -dm 755 /etc/apt/keyrings
+wget -qO - https://rtx.pub/gpg-key.pub | gpg --dearmor | sudo tee /etc/apt/keyrings/rtx-archive-keyring.gpg 1> /dev/null
+echo "deb [signed-by=/etc/apt/keyrings/rtx-archive-keyring.gpg arch=arm64] https://rtx.pub/deb stable main" | sudo tee /etc/apt/sources.list.d/rtx.list
 apt update
 apt install -y rtx
 rtx -V

--- a/README.md
+++ b/README.md
@@ -343,8 +343,9 @@ chmod +x /usr/local/bin/rtx
 For installation on Ubuntu/Debian:
 
 ```
-wget -qO - https://rtx.pub/gpg-key.pub | gpg --dearmor | sudo tee /usr/share/keyrings/rtx-archive-keyring.gpg 1> /dev/null
-echo "deb [signed-by=/usr/share/keyrings/rtx-archive-keyring.gpg arch=amd64] https://rtx.pub/deb stable main" | sudo tee /etc/apt/sources.list.d/rtx.list
+sudo install -dm 755 /etc/apt/keyrings
+wget -qO - https://rtx.pub/gpg-key.pub | gpg --dearmor | sudo tee /etc/apt/keyrings/rtx-archive-keyring.gpg 1> /dev/null
+echo "deb [signed-by=/etc/apt/keyrings/rtx-archive-keyring.gpg arch=amd64] https://rtx.pub/deb stable main" | sudo tee /etc/apt/sources.list.d/rtx.list
 sudo apt update
 sudo apt install -y rtx
 ```
@@ -354,7 +355,7 @@ sudo apt install -y rtx
 > If you're on arm64 you'll need to run the following:
 >
 > ```
-> echo "deb [signed-by=/usr/share/keyrings/rtx-archive-keyring.gpg arch=arm64] https://rtx.pub/deb stable main" | sudo tee /etc/apt/sources.list.d/rtx.list
+> echo "deb [signed-by=/etc/apt/keyrings/rtx-archive-keyring.gpg arch=arm64] https://rtx.pub/deb stable main" | sudo tee /etc/apt/sources.list.d/rtx.list
 > ```
 
 #### dnf


### PR DESCRIPTION
Per https://manpages.debian.org/bookworm/apt/sources.list.5.en.html#THE_DEB_AND_DEB-SRC_TYPES:_OPTIONS

> The recommended locations for keyrings are /usr/share/keyrings for
> keyrings managed by packages, and /etc/apt/keyrings for keyrings
> managed by the system operator.

Some older distros may not have the dir, create it.