### PR TITLE
print setting up virtualenv when virtualenv not exists

### DIFF
--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -116,7 +116,7 @@ impl PythonPlugin {
                 }
             }
             if !virtualenv.exists() || !self.check_venv_python(&virtualenv, tv)? {
-                debug!("setting up virtualenv at: {}", virtualenv.display());
+                info!("setting up virtualenv at: {}", virtualenv.display());
                 let mut cmd = CmdLineRunner::new(&config.settings, self.python_path(tv))
                     .arg("-m")
                     .arg("venv")


### PR DESCRIPTION
it prints log like this when virtualenv not exists

```
$ cd ansible-role-rtx/
[INFO] rtx::plugins::core::python: setting up virtualenv at: /home/deploy/ansible-role-rtx/.venv
```

https://github.com/jdxcode/rtx/issues/634#issuecomment-1638679327