### PR TITLE
refactor(python): invoke pip as `python -m pip`

### DIFF
--- a/src/plugins/core/python.rs
+++ b/src/plugins/core/python.rs
@@ -77,10 +77,6 @@ impl PythonPlugin {
         tv.install_path().join("bin/python")
     }
 
-    fn pip_path(&self, tv: &ToolVersion) -> PathBuf {
-        tv.install_path().join("bin/pip")
-    }
-
     fn install_default_packages(
         &self,
         settings: &Settings,
@@ -91,9 +87,10 @@ impl PythonPlugin {
             return Ok(());
         }
         pr.set_message("installing default packages");
-        let pip = self.pip_path(tv);
-        CmdLineRunner::new(settings, pip)
+        CmdLineRunner::new(settings, self.python_path(tv))
             .with_pr(pr)
+            .arg("-m")
+            .arg("pip")
             .arg("install")
             .arg("--upgrade")
             .arg("-r")


### PR DESCRIPTION
- https://snarky.ca/why-you-should-use-python-m-pip/
- https://pip.pypa.io/en/stable/user_guide/#using-pip-from-your-program

Caveat: untested.