### PR TITLE
rtx-use: show message after setting/removing versions

### DIFF
--- a/src/cli/global.rs
+++ b/src/cli/global.rs
@@ -27,7 +27,7 @@ pub struct Global {
     /// If this is a single tool with no version, the current value of the global
     /// .tool-versions will be displayed
     #[clap(value_name="TOOL@VERSION", value_parser = ToolArgParser, verbatim_doc_comment)]
-    tool: Option<Vec<ToolArg>>,
+    tool: Vec<ToolArg>,
 
     /// Save exact version to `~/.tool-versions`
     /// e.g.: `rtx global --pin node@20` will save `node 20.0.0` to ~/.tool-versions

--- a/src/cli/snapshots/rtx__cli__global__tests__global-2.snap
+++ b/src/cli/snapshots/rtx__cli__global__tests__global-2.snap
@@ -2,4 +2,5 @@
 source: src/cli/global.rs
 expression: output
 ---
+~/.test-tool-versions tiny@2
 

--- a/src/cli/snapshots/rtx__cli__global__tests__global-3.snap
+++ b/src/cli/snapshots/rtx__cli__global__tests__global-3.snap
@@ -2,4 +2,5 @@
 source: src/cli/global.rs
 expression: output
 ---
+~/.test-tool-versions tiny
 

--- a/src/cli/snapshots/rtx__cli__global__tests__global-4.snap
+++ b/src/cli/snapshots/rtx__cli__global__tests__global-4.snap
@@ -2,4 +2,5 @@
 source: src/cli/global.rs
 expression: output
 ---
+~/.test-tool-versions tiny@2
 

--- a/src/cli/snapshots/rtx__cli__global__tests__global.snap
+++ b/src/cli/snapshots/rtx__cli__global__tests__global.snap
@@ -2,4 +2,5 @@
 source: src/cli/global.rs
 expression: output
 ---
+~/.test-tool-versions tiny@2
 

--- a/src/cli/snapshots/rtx__cli__local__tests__local_multiple_versions-2.snap
+++ b/src/cli/snapshots/rtx__cli__local__tests__local_multiple_versions-2.snap
@@ -2,4 +2,5 @@
 source: src/cli/local.rs
 expression: output
 ---
+~/cwd/.test-tool-versions tiny@2 tiny@1 tiny@3
 

--- a/src/cli/snapshots/rtx__cli__local__tests__local_remove-2.snap
+++ b/src/cli/snapshots/rtx__cli__local__tests__local_remove-2.snap
@@ -2,4 +2,5 @@
 source: src/cli/local.rs
 expression: output
 ---
+~/cwd/.test-tool-versions tiny@2
 

--- a/src/cli/snapshots/rtx__cli__local__tests__local_remove-3.snap
+++ b/src/cli/snapshots/rtx__cli__local__tests__local_remove-3.snap
@@ -2,4 +2,5 @@
 source: src/cli/local.rs
 expression: output
 ---
+~/cwd/.test-tool-versions tiny
 

--- a/src/cli/snapshots/rtx__cli__local__tests__local_remove.snap
+++ b/src/cli/snapshots/rtx__cli__local__tests__local_remove.snap
@@ -2,4 +2,5 @@
 source: src/cli/local.rs
 expression: output
 ---
+~/cwd/.test-tool-versions tiny@2
 


### PR DESCRIPTION
also changed the logic slightly to find_up the nearest .rtx.toml if one does not exist
