### PR TITLE
help tweaks (#817)

### DIFF
--- a/src/plugins/core/go.rs
+++ b/src/plugins/core/go.rs
@@ -181,17 +181,19 @@ impl Plugin for GoPlugin {
 
     fn exec_env(&self, _config: &Config, tv: &ToolVersion) -> Result<HashMap<String, String>> {
         let mut map = HashMap::new();
-        if env::PRISTINE_ENV.get("GOROOT").is_none() && *env::RTX_GO_SET_GOROOT != Some(false) {
-            map.insert(
-                "GOROOT".to_string(),
-                self.goroot(tv).to_string_lossy().to_string(),
-            );
+        match (*env::RTX_GO_SET_GOROOT, env::PRISTINE_ENV.get("GOROOT")) {
+            (Some(false), _) | (None, Some(_)) => {}
+            (Some(true), _) | (None, None) => {
+                let goroot = self.goroot(tv).to_string_lossy().to_string();
+                map.insert("GOROOT".to_string(), goroot);
+            }
         };
-        if env::PRISTINE_ENV.get("GOPATH").is_none() && *env::RTX_GO_SET_GOPATH != Some(false) {
-            map.insert(
-                "GOPATH".to_string(),
-                self.gopath(tv).to_string_lossy().to_string(),
-            );
+        match (*env::RTX_GO_SET_GOPATH, env::PRISTINE_ENV.get("GOPATH")) {
+            (Some(false), _) | (None, Some(_)) => {}
+            (Some(true), _) | (None, None) => {
+                let gopath = self.gopath(tv).to_string_lossy().to_string();
+                map.insert("GOPATH".to_string(), gopath);
+            }
         };
         Ok(map)
     }


### PR DESCRIPTION
Fixes #815 

```
❯ RTX_GO_SET_GOPATH=1 GOPATH=xyz rtx x -- env | grep GOPATH=
GOPATH=/Users/jdx/.rtx/installs/go/1.20.7/packages
RTX_GO_SET_GOPATH=1
❯ RTX_GO_SET_GOPATH=0 GOPATH=xyz rtx x -- env | grep GOPATH=
GOPATH=xyz
RTX_GO_SET_GOPATH=0
❯ GOPATH=xyz rtx x -- env | grep GOPATH=
GOPATH=xyz
❯ RTX_GO_SET_GOPATH=1 rtx x -- env | grep GOPATH=
RTX_GO_SET_GOPATH=1
GOPATH=/Users/jdx/.rtx/installs/go/1.20.7/packages
❯ RTX_GO_SET_GOPATH=0 rtx x -- env | grep GOPATH=
RTX_GO_SET_GOPATH=0
```