### PR TITLE
Adding check for `CI`

### DIFF
--- a/src/plugins/external_plugin.rs
+++ b/src/plugins/external_plugin.rs
@@ -415,7 +415,8 @@ impl Plugin for ExternalPlugin {
                     name = style(&self.name).cyan(),
                     url = style(url.trim_end_matches(".git")).yellow(),
                 );
-                if !prompt::confirm(&format!("Would you like to install {}?", self.name))? {
+                let in_ci = env::var("CI").unwrap_or("false".to_string()) == "true";
+                if !in_ci && !prompt::confirm(&format!("Would you like to install {}?", self.name))? {
                     Err(PluginNotInstalled(self.name.clone()))?
                 }
             }


### PR DESCRIPTION
Per the convo [here](https://github.com/jdxcode/rtx-action/pull/123), you wanted a `CI` check before error-ing on lack of prompt.

It's possible you also want this check for marking `.rtx.toml` files as trusted implicitly, but I think tackling that might be more involved.