### PR TITLE
stop overwriting pre_prompt and PWD in nushell.rs

### DIFF
--- a/src/shell/nushell.rs
+++ b/src/shell/nushell.rs
@@ -41,15 +41,17 @@ impl Shell for Nushell {
             $env.RTX_SHELL = "nu"
             
             $env.config = ($env.config | upsert hooks {{
-                pre_prompt: [{{
+                pre_prompt: ($env.config.hooks.pre_prompt ++
+                [{{
                 condition: {{|| "RTX_SHELL" in $env }}
                 code: {{|| rtx_hook }}
-                }}]
+                }}])
                 env_change: {{
-                    PWD: [{{
+                    PWD: ($env.config.hooks.env_change.PWD ++
+                    [{{
                     condition: {{|| "RTX_SHELL" in $env }}
                     code: {{|| rtx_hook }}
-                    }}]
+                    }}])
                 }}
             }})
           }}

--- a/src/shell/snapshots/rtx__shell__nushell__tests__hook_init.snap
+++ b/src/shell/snapshots/rtx__shell__nushell__tests__hook_init.snap
@@ -7,15 +7,17 @@ export-env {
   $env.RTX_SHELL = "nu"
   
   $env.config = ($env.config | upsert hooks {
-      pre_prompt: [{
+      pre_prompt: ($env.config.hooks.pre_prompt ++
+      [{
       condition: {|| "RTX_SHELL" in $env }
       code: {|| rtx_hook }
-      }]
+      }])
       env_change: {
-          PWD: [{
+          PWD: ($env.config.hooks.env_change.PWD ++
+          [{
           condition: {|| "RTX_SHELL" in $env }
           code: {|| rtx_hook }
-          }]
+          }])
       }
   })
 }

--- a/src/shell/snapshots/rtx__shell__nushell__tests__hook_init_nix.snap
+++ b/src/shell/snapshots/rtx__shell__nushell__tests__hook_init_nix.snap
@@ -6,15 +6,17 @@ export-env {
   $env.RTX_SHELL = "nu"
   
   $env.config = ($env.config | upsert hooks {
-      pre_prompt: [{
+      pre_prompt: ($env.config.hooks.pre_prompt ++
+      [{
       condition: {|| "RTX_SHELL" in $env }
       code: {|| rtx_hook }
-      }]
+      }])
       env_change: {
-          PWD: [{
+          PWD: ($env.config.hooks.env_change.PWD ++
+          [{
           condition: {|| "RTX_SHELL" in $env }
           code: {|| rtx_hook }
-          }]
+          }])
       }
   })
 }


### PR DESCRIPTION
I tried to use rtx along with direnv on nushell, and found `source "~/Library/Application Support/nushell/rtx.nu"` overwrites hook from direnv.
Editing my rtx.nu like this fixes the problem on my environment.