### PR TITLE
Fix `install.sh` output

### DIFF
--- a/packaging/standalone/install.envsubst
+++ b/packaging/standalone/install.envsubst
@@ -138,19 +138,22 @@ after_finish_help() {
 	case "${SHELL:-}" in
 	*/zsh)
 		info "rtx: run the following to activate rtx in your shell:"
-		info "echo \"eval \\\"\\\$($install_path activate zsh)\\\"\" >> ~/.zshrc\n"
+		info "echo \"eval \\\"\\\$($install_path activate zsh)\\\"\" >> ~/.zshrc"
+		info ""
 		info "rtx: this must be run in order to use rtx in the terminal"
 		info "rtx: run \`rtx doctor\` to verify this is setup correctly"
 		;;
 	*/bash)
 		info "rtx: run the following to activate rtx in your shell:"
-		info "echo \"eval \\\"\\\$($install_path activate bash)\\\"\" >> ~/.bashrc\n"
+		info "echo \"eval \\\"\\\$($install_path activate bash)\\\"\" >> ~/.bashrc"
+		info ""
 		info "rtx: this must be run in order to use rtx in the terminal"
 		info "rtx: run \`rtx doctor\` to verify this is setup correctly"
 		;;
 	*/fish)
 		info "rtx: run the following to activate rtx in your shell:"
-		info "echo \"$install_path activate fish | source\" >> ~/.config/fish/config.fish\n"
+		info "echo \"$install_path activate fish | source\" >> ~/.config/fish/config.fish"
+		info ""
 		info "rtx: this must be run in order to use rtx in the terminal"
 		info "rtx: run \`rtx doctor\` to verify this is setup correctly"
 		;;


### PR DESCRIPTION
The behavior of the `echo` command and its handling of escape sequences, such as `\n`, can exhibit variability across different implementations of shells and utilities. This variability was evident during my experience while executing the `install.sh` script on a newly installed Fedora system:

```bash
[xander@fedora ~]$ curl https://rtx.pub/install.sh | sh
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100  4302  100  4302    0     0  78350      0 --:--:-- --:--:-- --:--:-- 79666
rtx: installing rtx...
rtx: installed successfully to /home/xander/.local/share/rtx/bin/rtx
rtx: run the following to activate rtx in your shell:
echo "eval \"\$(/home/xander/.local/share/rtx/bin/rtx activate bash)\"" >> ~/.bashrc\n # <--newline
rtx: this must be run in order to use rtx in the terminal
rtx: run `rtx doctor` to verify this is setup correctly
```

Furthermore, a direct copy-paste of the command could potentially lead to unintended consequences. For instance, when executed in a bash shell, the command may inadvertently remove the trailing backslash:

```bash
[xander@fedora ~]$ echo "eval \"\$(/home/xander/.local/share/rtx/bin/rtx activate bash)\"" >> ~/.bashrc\n
[xander@fedora ~]$ cat .bashrcn # note the `n` at the end
eval "$(/home/xander/.local/share/rtx/bin/rtx activate bash)"
[xander@fedora ~]
```

Podman testing showed consistent `echo` behavior with bash across distributions, except for Debian and Ubuntu (using dash) which interpret escape sequences by default. Thus, replacing the newlines with empty `info` calls appears to be the most portable solution.